### PR TITLE
Update CF CookieSigner to use crypto.Signer interface

### DIFF
--- a/.changelog/2d985a5397e54093835ad0df5998435f.json
+++ b/.changelog/2d985a5397e54093835ad0df5998435f.json
@@ -1,0 +1,8 @@
+{
+    "id": "2d985a53-97e5-4093-835a-d0df5998435f",
+    "type": "feature",
+    "description": "Support ECDSA for CloudFront sign cookies",
+    "modules": [
+        "feature/cloudfront/sign"
+    ]
+}

--- a/feature/cloudfront/sign/sign_cookie.go
+++ b/feature/cloudfront/sign/sign_cookie.go
@@ -1,7 +1,7 @@
 package sign
 
 import (
-	"crypto/rsa"
+	"crypto"
 	"fmt"
 	"net/http"
 	"strings"
@@ -55,22 +55,20 @@ func (o CookieOptions) apply(opts ...func(*CookieOptions)) CookieOptions {
 // The signer is safe to use concurrently, but the optional cookies options
 // are not safe to modify concurrently.
 type CookieSigner struct {
-	keyID   string
-	privKey *rsa.PrivateKey
+	keyID  string
+	signer crypto.Signer
 
 	Opts CookieOptions
 }
 
 // NewCookieSigner constructs and returns a new CookieSigner to be used to for
 // signing Amazon CloudFront URL resources with.
-func NewCookieSigner(keyID string, privKey *rsa.PrivateKey, opts ...func(*CookieOptions)) *CookieSigner {
-	signer := &CookieSigner{
-		keyID:   keyID,
-		privKey: privKey,
-		Opts:    CookieOptions{}.apply(opts...),
+func NewCookieSigner(keyID string, signer crypto.Signer, opts ...func(*CookieOptions)) *CookieSigner {
+	return &CookieSigner{
+		keyID:  keyID,
+		signer: signer,
+		Opts:   CookieOptions{}.apply(opts...),
 	}
-
-	return signer
 }
 
 // Sign returns the cookies needed to allow user agents to make arbetrary
@@ -84,7 +82,7 @@ func NewCookieSigner(keyID string, privKey *rsa.PrivateKey, opts ...func(*Cookie
 //
 // Example:
 //
-//	s := sign.NewCookieSigner(keyID, privKey)
+//	s := sign.NewCookieSigner(keyID, signer)
 //
 //	// Get Signed cookies for a resource that will expire in 1 hour
 //	cookies, err := s.Sign("*", time.Now().Add(1 * time.Hour))
@@ -127,7 +125,7 @@ func (s CookieSigner) Sign(u string, expires time.Time, opts ...func(*CookieOpti
 	}
 
 	p := NewCannedPolicy(resource, expires)
-	return createCookies(p, s.keyID, s.privKey, s.Opts.apply(opts...))
+	return createCookies(p, s.keyID, s.signer, s.Opts.apply(opts...))
 }
 
 // Returns and validates the URL's scheme.
@@ -154,7 +152,7 @@ func cookieURLScheme(u string) (string, error) {
 //
 // Example:
 //
-//	s := sign.NewCookieSigner(keyID, privKey)
+//	s := sign.NewCookieSigner(keyID, signer)
 //
 //	policy := &sign.Policy{
 //	    Statements: []sign.Statement{
@@ -204,13 +202,13 @@ func cookieURLScheme(u string) (string, error) {
 //	    }
 //	}
 func (s CookieSigner) SignWithPolicy(p *Policy, opts ...func(*CookieOptions)) ([]*http.Cookie, error) {
-	return createCookies(p, s.keyID, s.privKey, s.Opts.apply(opts...))
+	return createCookies(p, s.keyID, s.signer, s.Opts.apply(opts...))
 }
 
 // Prepares the cookies to be attached to the header. An (optional) options
 // struct is provided in case people don't want to manually edit their cookies.
-func createCookies(p *Policy, keyID string, privKey *rsa.PrivateKey, opt CookieOptions) ([]*http.Cookie, error) {
-	b64Sig, b64Policy, err := p.Sign(privKey)
+func createCookies(p *Policy, keyID string, signer crypto.Signer, opt CookieOptions) ([]*http.Cookie, error) {
+	b64Sig, b64Policy, err := p.Sign(signer)
 	if err != nil {
 		return nil, err
 	}

--- a/feature/cloudfront/sign/sign_cookie_test.go
+++ b/feature/cloudfront/sign/sign_cookie_test.go
@@ -1,6 +1,8 @@
 package sign
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
 	"crypto/rsa"
 	"testing"
 	"time"
@@ -16,7 +18,7 @@ func TestNewCookieSigner(t *testing.T) {
 	if e, a := "keyID", signer.keyID; e != a {
 		t.Errorf("expect %v, got %v", e, a)
 	}
-	if e, a := privKey, signer.privKey; e != a {
+	if e, a := privKey, signer.signer; e != a {
 		t.Errorf("expect %v, got %v", e, a)
 	}
 }
@@ -117,5 +119,28 @@ func TestSignCookie_WithCookieOptions(t *testing.T) {
 		if !c.Secure {
 			t.Errorf("expect to be true")
 		}
+	}
+}
+
+func TestSignCookie_ECDSA(t *testing.T) {
+	privKey, err := ecdsa.GenerateKey(elliptic.P256(), randReader)
+	if err != nil {
+		t.Errorf("expect no error, got %v", err)
+	}
+
+	signer := NewCookieSigner("keyID", privKey)
+	cookies, err := signer.Sign("http*://*", time.Now().Add(1*time.Hour))
+
+	if err != nil {
+		t.Errorf("expect no error, got %v", err)
+	}
+	if e, a := CookiePolicyName, cookies[0].Name; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := CookieSignatureName, cookies[1].Name; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := CookieKeyIDName, cookies[2].Name; e != a {
+		t.Errorf("expect %v, got %v", e, a)
 	}
 }


### PR DESCRIPTION
Updates `CookieSigner` to use `crypto.Signer` in order to support ECDSA keys and other signing methods.

CloudFront supports ECDSA since 2025, but `CookieSigner` accepts only `*rsa.PrivateKey` and thus prevents users from using ECDSA in Go. This change makes `CookieSigner` accept `*ecdsa.PrivateKey` and other signing methods in addition to `*rsa.PrivateKey` (which also implements crypto.Signer). Existing `*rsa.PrivateKey` usage is compatible with this change.

For `URLSigner`, #2087 has resolved the problem.
