### PR TITLE
apigatewayv2: update SecurityPolicy

### DIFF
--- a/service/apigatewayv2/types/enums.go
+++ b/service/apigatewayv2/types/enums.go
@@ -323,8 +323,18 @@ type SecurityPolicy string
 
 // Enum values for SecurityPolicy
 const (
-	SecurityPolicyTls10 SecurityPolicy = "TLS_1_0"
-	SecurityPolicyTls12 SecurityPolicy = "TLS_1_2"
+	SecurityPolicyTls10                                SecurityPolicy = "TLS_1_0"
+	SecurityPolicyTls12                                SecurityPolicy = "TLS_1_2"
+	SecurityPolicySecurityPolicyTls1313202509          SecurityPolicy = "SecurityPolicy_TLS13_1_3_2025_09"
+	SecurityPolicySecurityPolicyTls1313Fips202509      SecurityPolicy = "SecurityPolicy_TLS13_1_3_FIPS_2025_09"
+	SecurityPolicySecurityPolicyTls1312PfsPq202509     SecurityPolicy = "SecurityPolicy_TLS13_1_2_PFS_PQ_2025_09"
+	SecurityPolicySecurityPolicyTls1312FipsPq202509    SecurityPolicy = "SecurityPolicy_TLS13_1_2_FIPS_PQ_2025_09"
+	SecurityPolicySecurityPolicyTls1312FipsPfsPq202509 SecurityPolicy = "SecurityPolicy_TLS13_1_2_FIPS_PFS_PQ_2025_09"
+	SecurityPolicySecurityPolicyTls1312Pq202509        SecurityPolicy = "SecurityPolicy_TLS13_1_2_PQ_2025_09"
+	SecurityPolicySecurityPolicyTls1312202106          SecurityPolicy = "SecurityPolicy_TLS13_1_2_2021_06"
+	SecurityPolicySecurityPolicyTls132025Edge          SecurityPolicy = "SecurityPolicy_TLS13_2025_EDGE"
+	SecurityPolicySecurityPolicyTls12Pfs2025Edge       SecurityPolicy = "SecurityPolicy_TLS12_PFS_2025_EDGE"
+	SecurityPolicySecurityPolicyTls122018Edge          SecurityPolicy = "SecurityPolicy_TLS12_2018_EDGE"
 )
 
 // Values returns all known values for SecurityPolicy. Note that this can be
@@ -335,6 +345,16 @@ func (SecurityPolicy) Values() []SecurityPolicy {
 	return []SecurityPolicy{
 		"TLS_1_0",
 		"TLS_1_2",
+		"SecurityPolicy_TLS13_1_3_2025_09",
+		"SecurityPolicy_TLS13_1_3_FIPS_2025_09",
+		"SecurityPolicy_TLS13_1_2_PFS_PQ_2025_09",
+		"SecurityPolicy_TLS13_1_2_FIPS_PQ_2025_09",
+		"SecurityPolicy_TLS13_1_2_FIPS_PFS_PQ_2025_09",
+		"SecurityPolicy_TLS13_1_2_PQ_2025_09",
+		"SecurityPolicy_TLS13_1_2_2021_06",
+		"SecurityPolicy_TLS13_2025_EDGE",
+		"SecurityPolicy_TLS12_PFS_2025_EDGE",
+		"SecurityPolicy_TLS12_2018_EDGE",
 	}
 }
 

--- a/service/apigatewayv2/types/types.go
+++ b/service/apigatewayv2/types/types.go
@@ -475,8 +475,7 @@ type DomainNameConfiguration struct {
 	// imported or private CA certificate ARN as the regionalCertificateArn
 	OwnershipVerificationCertificateArn *string
 
-	// The Transport Layer Security (TLS) version of the security policy for this
-	// domain name. The valid values are TLS_1_0 and TLS_1_2.
+	// The Transport Layer Security (TLS) version + cipher suite for this DomainName.
 	SecurityPolicy SecurityPolicy
 
 	noSmithyDocumentSerde


### PR DESCRIPTION
Add the security policies actually supported by the service. This is C&P from the apigateway implementation that support the same set of security policies.

This should fix https://github.com/hashicorp/terraform-provider-aws/issues/46611.