### PR TITLE
fix(service/s3/validators): validate empty bucket to prevent panic in dnsCompatibleBucketName method

### DIFF
--- a/service/s3/internal/customizations/update_endpoint.go
+++ b/service/s3/internal/customizations/update_endpoint.go
@@ -278,7 +278,7 @@ func hostCompatibleBucketName(u *url.URL, bucket string) bool {
 // dnsCompatibleBucketName returns true if the bucket name is DNS compatible.
 // Buckets created outside of the classic region MUST be DNS compatible.
 func dnsCompatibleBucketName(bucket string) bool {
-	if strings.Contains(bucket, "..") {
+	if bucket == "" || strings.Contains(bucket, "..") {
 		return false
 	}
 

--- a/service/s3/internal/customizations/update_endpoint_internal_test.go
+++ b/service/s3/internal/customizations/update_endpoint_internal_test.go
@@ -74,3 +74,49 @@ func TestRemoveBucketFromPath(t *testing.T) {
 		})
 	}
 }
+
+func TestDNSCompatibleBucketName(t *testing.T) {
+	cases := []struct {
+		bucket   string
+		expected bool
+	}{
+		// valid bucket names
+		{"abc", true},
+		{"a", true},
+		{"ab", true},
+		{"my-bucket", true},
+		{"my.bucket", true},
+		{"my-bucket-123", true},
+		{"123bucket", true},
+		{"a1b2c3", true},
+		{"bucket.with.dots", true},
+		// empty bucket
+		{"", false},
+		// consecutive dots
+		{"a..bc", false},
+		// invalid characters
+		{"a$b$c", false},
+		{"bucket_name", false},
+		{"UPPERCASE", false},
+		{"Bucket", false},
+		{"bucket name", false},
+		{"bucket@name", false},
+		// starts with invalid character
+		{".bucket", false},
+		{"-bucket", false},
+		// IP address
+		{"127.0.0.1", false},
+		{"192.168.1.1", false},
+		// not IP (4 parts but with non-numeric chars)
+		{"a.b.c.d", true},
+		{"1.2.3.abc", true},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.bucket, func(t *testing.T) {
+			if got := dnsCompatibleBucketName(tt.bucket); got != tt.expected {
+				t.Errorf("dnsCompatibleBucketName(%q) = %v, want %v", tt.bucket, got, tt.expected)
+			}
+		})
+	}
+}

--- a/service/s3/validators.go
+++ b/service/s3/validators.go
@@ -5966,7 +5966,7 @@ func validateOpPutObjectInput(v *PutObjectInput) error {
 		return nil
 	}
 	invalidParams := smithy.InvalidParamsError{Context: "PutObjectInput"}
-	if v.Bucket == nil {
+	if v.Bucket == nil || *v.Bucket == "" {
 		invalidParams.Add(smithy.NewErrParamRequired("Bucket"))
 	}
 	if v.Key == nil {

--- a/service/s3/validators.go
+++ b/service/s3/validators.go
@@ -5966,7 +5966,7 @@ func validateOpPutObjectInput(v *PutObjectInput) error {
 		return nil
 	}
 	invalidParams := smithy.InvalidParamsError{Context: "PutObjectInput"}
-	if v.Bucket == nil || *v.Bucket == "" {
+	if v.Bucket == nil {
 		invalidParams.Add(smithy.NewErrParamRequired("Bucket"))
 	}
 	if v.Key == nil {


### PR DESCRIPTION
## Description  
Fixes a panic in `dnsCompatibleBucketName` when an empty bucket name is provided.

The function assumes a non-empty string and directly accesses `bucket[0]`, which causes a runtime panic when `bucket == ""`.

**Before (bug):**  
- Empty bucket name (`""`) is not handled  
- Code accesses `bucket[0]` → out-of-bounds panic  

**After (fix):**  
- Empty bucket name is explicitly handled  
- Function safely returns `false` before any indexing  

---

## Root Cause  
`dnsCompatibleBucketName` directly indexes the first character:

```go
if !((bucket[0] > 96 && bucket[0] < 123) || (bucket[0] > 47 && bucket[0] < 58)) {
    return false
}