### PR TITLE
Make AccountIDEndpointRouting aware of bdd endpoints

### DIFF
--- a/codegen/smithy-aws-go-codegen/src/main/java/software/amazon/smithy/aws/go/codegen/customization/AccountIDEndpointRouting.java
+++ b/codegen/smithy-aws-go-codegen/src/main/java/software/amazon/smithy/aws/go/codegen/customization/AccountIDEndpointRouting.java
@@ -11,7 +11,9 @@ import software.amazon.smithy.aws.go.codegen.AwsGoDependency;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.rulesengine.language.syntax.Identifier;
+import software.amazon.smithy.rulesengine.language.syntax.parameters.Parameters;
 import software.amazon.smithy.rulesengine.traits.EndpointRuleSetTrait;
+import software.amazon.smithy.rulesengine.traits.EndpointBddTrait;
 import software.amazon.smithy.utils.MapUtils;
 
 import static software.amazon.smithy.go.codegen.GoWriter.goTemplate;
@@ -76,12 +78,17 @@ public class AccountIDEndpointRouting implements GoIntegration {
     }
 
     public static boolean hasAccountIdEndpoints(Model model, ServiceShape service) {
-        if (!service.hasTrait(EndpointRuleSetTrait.class)) {
+        if (!service.hasTrait(EndpointRuleSetTrait.class) && !service.hasTrait(EndpointBddTrait.class)) {
             return false;
         }
-
-        var rules = service.expectTrait(EndpointRuleSetTrait.class).getEndpointRuleSet();
-        for (var param : rules.getParameters()) {
+        Parameters parameters;
+        if (service.hasTrait(EndpointRuleSetTrait.class)) {
+            var rules = service.expectTrait(EndpointRuleSetTrait.class).getEndpointRuleSet();
+            parameters = rules.getParameters();
+        } else {
+            parameters = service.expectTrait(EndpointBddTrait.class).getParameters();
+        }
+        for (var param : parameters) {
             if (param.getBuiltIn().orElse("").equals("AWS::Auth::AccountId")) {
                 return true;
             }


### PR DESCRIPTION
We recently made a change in #3360 to only generate `resolveAccountID` when it's needed. That PR uses an existing method `hasAccountIdEndpoints` to see if the endpoint has any parameter that reference `AWS::Auth::AccountId`. Now that we'll be supporting `EndpointBddTrait`, we need to also check that trait to see if it contains an accountid parameter

NOTE: While related to BDD, this is unrelated to the current rollback in #3385 and it's an independent change