### PR TITLE
bump to latest smithy-go codegen

### DIFF
--- a/SMITHY_GO_CODEGEN_VERSION
+++ b/SMITHY_GO_CODEGEN_VERSION
@@ -1,1 +1,1 @@
-5beb80e9da6bcad40dc304f062c27d8269abd67d
+be5e5ef0d73560eac9d71df7995b0eaffb9a8d71


### PR DESCRIPTION
bump smithy go codegen following latest fix https://github.com/aws/smithy-go/pull/649
