### PR TITLE
[transfermanager] Allow downloading directories that contain filenames with double dots

### DIFF
--- a/.changelog/1c88b192e747436c998a32096006308c.json
+++ b/.changelog/1c88b192e747436c998a32096006308c.json
@@ -1,0 +1,8 @@
+{
+    "id": "1c88b192-e747-436c-998a-32096006308c",
+    "type": "bugfix",
+    "description": "Loose download directory check to allow downloading objects with double dot",
+    "modules": [
+        "feature/s3/transfermanager"
+    ]
+}

--- a/.changelog/1c88b192e747436c998a32096006308c.json
+++ b/.changelog/1c88b192e747436c998a32096006308c.json
@@ -1,7 +1,7 @@
 {
     "id": "1c88b192-e747-436c-998a-32096006308c",
     "type": "bugfix",
-    "description": "Loose download directory check to allow downloading objects with double dot",
+    "description": "Loose download directory check to allow downloading objects with double dot in filename",
     "modules": [
         "feature/s3/transfermanager"
     ]

--- a/feature/s3/transfermanager/api_op_DownloadDirectory.go
+++ b/feature/s3/transfermanager/api_op_DownloadDirectory.go
@@ -236,7 +236,7 @@ func (d *directoryDownloader) getLocalPath(key string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if relPath == "." || strings.Contains(relPath, "..") {
+	if relPath == "." || !filepath.IsLocal(relPath) {
 		return "", fmt.Errorf("resolved local path %s is outside of destination %s", path, destination)
 	}
 

--- a/feature/s3/transfermanager/download_directory_test.go
+++ b/feature/s3/transfermanager/download_directory_test.go
@@ -280,12 +280,12 @@ func TestDownloadDirectory(t *testing.T) {
 				l.expectFailed(t, in, err)
 			},
 		},
-		"object key with double dots in name": {
-			destination: "double-dots-in-name",
+		"object key with double dots in name and path": {
+			destination: "double-dots-in-name-and-path",
 			objectsLists: [][]s3types.Object{
 				{
 					{
-						Key: aws.String("foo/bar..baz"),
+						Key: aws.String("foo/bar/../baz..zoo"),
 					},
 					{
 						Key: aws.String("a..b"),
@@ -293,12 +293,31 @@ func TestDownloadDirectory(t *testing.T) {
 				},
 			},
 			expectTokens:            []string{""},
-			expectKeys:              []string{"foo/bar..baz", "a..b"},
-			expectFiles:             []string{"foo/bar..baz", "a..b"},
+			expectKeys:              []string{"foo/bar/../baz..zoo", "a..b"},
+			expectFiles:             []string{"foo/baz..zoo", "a..b"},
 			expectObjectsDownloaded: 2,
 			listenerValidationFn: func(t *testing.T, l *mockDirectoryListener, in, out any, err error) {
 				l.expectStart(t, in)
 				l.expectComplete(t, in, out, 2)
+			},
+		},
+		"object key with double dots in name and path escaping": {
+			destination: "double-dots-in-name-and-path-escaping",
+			objectsLists: [][]s3types.Object{
+				{
+					{
+						Key: aws.String("foo/../../baz..zoo"),
+					},
+					{
+						Key: aws.String("a..b"),
+					},
+				},
+			},
+			expectErr: "outside of destination",
+			listenerValidationFn: func(t *testing.T, l *mockDirectoryListener, in, out any, err error) {
+				// only validate failure listener since start listener
+				// might never be triggerred if the error response is returned first
+				l.expectFailed(t, in, err)
 			},
 		},
 		"multiple objects with filter applied": {

--- a/feature/s3/transfermanager/download_directory_test.go
+++ b/feature/s3/transfermanager/download_directory_test.go
@@ -280,6 +280,27 @@ func TestDownloadDirectory(t *testing.T) {
 				l.expectFailed(t, in, err)
 			},
 		},
+		"object key with double dots in name": {
+			destination: "double-dots-in-name",
+			objectsLists: [][]s3types.Object{
+				{
+					{
+						Key: aws.String("foo/bar..baz"),
+					},
+					{
+						Key: aws.String("a..b"),
+					},
+				},
+			},
+			expectTokens:            []string{""},
+			expectKeys:              []string{"foo/bar..baz", "a..b"},
+			expectFiles:             []string{"foo/bar..baz", "a..b"},
+			expectObjectsDownloaded: 2,
+			listenerValidationFn: func(t *testing.T, l *mockDirectoryListener, in, out any, err error) {
+				l.expectStart(t, in)
+				l.expectComplete(t, in, out, 2)
+			},
+		},
 		"multiple objects with filter applied": {
 			destination: "multiple-objects-with-filter-applied",
 			objectsLists: [][]s3types.Object{


### PR DESCRIPTION

### Summary
Fix overly strict path traversal check in DownloadDirectory.

### Problem
The current implementation uses:
strings.Contains(relPath, "..")

This incorrectly rejects valid filenames such as:
- file..txt

### Solution
Replace with:
!filepath.IsLocal(relPath)

This:
- still prevents traversal (../)
- allows valid filenames containing '..'

### Test
Updated TestDownloadDirectory to verify files with '..' in their names are allowed.
All unit tests pass.
