### PR TITLE
Support SHA-256 on CloudFront signing

### DIFF
--- a/.changelog/be39059ccba040b7b18533e66fe2b8cb.json
+++ b/.changelog/be39059ccba040b7b18533e66fe2b8cb.json
@@ -1,0 +1,8 @@
+{
+    "id": "be39059c-cba0-40b7-b185-33e66fe2b8cb",
+    "type": "feature",
+    "description": "Support SHA-256 for CloudFront signer",
+    "modules": [
+        "feature/cloudfront/sign"
+    ]
+}

--- a/feature/cloudfront/sign/policy.go
+++ b/feature/cloudfront/sign/policy.go
@@ -5,15 +5,42 @@ import (
 	"crypto"
 	"crypto/rand"
 	"crypto/sha1"
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"hash"
 	"io"
 	"net/url"
 	"strings"
 	"time"
 	"unicode"
 )
+
+// HashAlgorithm determines the hash algorithm used when signing CloudFront
+// URLs and cookies. The zero value (empty string) defaults to SHA-1 for
+// backward compatibility.
+type HashAlgorithm string
+
+const (
+	// HashSHA1 uses SHA-1 for signing (default, backward compatible).
+	HashSHA1 HashAlgorithm = "SHA1"
+
+	// HashSHA256 uses SHA-256 for signing. Requires appending
+	// Hash-Algorithm=SHA256 to the signed URL or cookie.
+	HashSHA256 HashAlgorithm = "SHA256"
+)
+
+func (h HashAlgorithm) hash() (hash.Hash, crypto.Hash, error) {
+	switch h {
+	case HashSHA256:
+		return sha256.New(), crypto.SHA256, nil
+	case HashSHA1, "":
+		return sha1.New(), crypto.SHA1, nil
+	default:
+		return nil, 0, fmt.Errorf("unsupported hash algorithm %q", h)
+	}
+}
 
 // An AWSEpochTime wraps a time value providing JSON serialization needed for
 // AWS Policy epoch time fields.
@@ -92,19 +119,23 @@ var randReader = rand.Reader
 // guidelines in:
 // http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-signed-urls.html
 func (p *Policy) Sign(signer crypto.Signer) (b64Signature, b64Policy []byte, err error) {
+	return p.SignWithHash(signer, HashSHA1)
+}
+
+// SignWithHash will sign a policy using the specified hash algorithm. It will
+// return a base 64 encoded signature and policy if no error is encountered.
+func (p *Policy) SignWithHash(signer crypto.Signer, hash HashAlgorithm) (b64Signature, b64Policy []byte, err error) {
 	if err = p.Validate(); err != nil {
 		return nil, nil, err
 	}
 
-	// Build and escape the policy
 	b64Policy, jsonPolicy, err := encodePolicy(p)
 	if err != nil {
 		return nil, nil, err
 	}
 	awsEscapeEncoded(b64Policy)
 
-	// Build and escape the signature
-	b64Signature, err = signEncodedPolicy(randReader, jsonPolicy, signer)
+	b64Signature, err = signEncodedPolicy(randReader, jsonPolicy, signer, hash)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -198,13 +229,16 @@ func encodePolicy(p *Policy) (b64Policy, jsonPolicy []byte, err error) {
 }
 
 // signEncodedPolicy will sign and base 64 encode the JSON encoded policy.
-func signEncodedPolicy(randReader io.Reader, jsonPolicy []byte, signer crypto.Signer) ([]byte, error) {
-	hash := sha1.New()
-	if _, err := bytes.NewReader(jsonPolicy).WriteTo(hash); err != nil {
+func signEncodedPolicy(randReader io.Reader, jsonPolicy []byte, signer crypto.Signer, hashAlg HashAlgorithm) ([]byte, error) {
+	h, cryptoHash, err := hashAlg.hash()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := bytes.NewReader(jsonPolicy).WriteTo(h); err != nil {
 		return nil, fmt.Errorf("failed to calculate signing hash, %s", err.Error())
 	}
 
-	sig, err := signer.Sign(randReader, hash.Sum(nil), crypto.SHA1)
+	sig, err := signer.Sign(randReader, h.Sum(nil), cryptoHash)
 	if err != nil {
 		return nil, fmt.Errorf("failed to sign policy, %s", err.Error())
 	}

--- a/feature/cloudfront/sign/policy.go
+++ b/feature/cloudfront/sign/policy.go
@@ -119,12 +119,12 @@ var randReader = rand.Reader
 // guidelines in:
 // http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-signed-urls.html
 func (p *Policy) Sign(signer crypto.Signer) (b64Signature, b64Policy []byte, err error) {
-	return p.SignWithHash(signer, HashSHA1)
+	return p.SignWithAlgorithm(signer, HashSHA1)
 }
 
-// SignWithHash will sign a policy using the specified hash algorithm. It will
+// SignWithAlgorithm will sign a policy using the specified hash algorithm. It will
 // return a base 64 encoded signature and policy if no error is encountered.
-func (p *Policy) SignWithHash(signer crypto.Signer, hash HashAlgorithm) (b64Signature, b64Policy []byte, err error) {
+func (p *Policy) SignWithAlgorithm(signer crypto.Signer, hash HashAlgorithm) (b64Signature, b64Policy []byte, err error) {
 	if err = p.Validate(); err != nil {
 		return nil, nil, err
 	}

--- a/feature/cloudfront/sign/policy_test.go
+++ b/feature/cloudfront/sign/policy_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto"
 	"crypto/rsa"
 	"crypto/sha1"
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -155,7 +156,7 @@ func TestSignEncodedPolicy(t *testing.T) {
 		t.Fatalf("Unexpected priv key error, %#v", err)
 	}
 
-	b64Signature, err := signEncodedPolicy(r, jsonPolicy, privKey)
+	b64Signature, err := signEncodedPolicy(r, jsonPolicy, privKey, HashSHA1)
 	if err != nil {
 		t.Fatalf("Unexpected policy sign error, %#v", err)
 	}
@@ -172,6 +173,62 @@ func TestSignEncodedPolicy(t *testing.T) {
 
 	if err := rsa.VerifyPKCS1v15(&privKey.PublicKey, crypto.SHA1, hash.Sum(nil), decodedSig); err != nil {
 		t.Fatalf("Unable to verify signature, %#v", err)
+	}
+}
+
+func TestSignEncodedPolicySHA256(t *testing.T) {
+	p := NewCannedPolicy("https://example.com/a", testTime)
+	_, jsonPolicy, err := encodePolicy(p)
+	if err != nil {
+		t.Fatalf("Unexpected policy encode error, %#v", err)
+	}
+
+	r := newRandomReader(rand.New(rand.NewSource(1)))
+
+	privKey, err := rsa.GenerateKey(r, 1024)
+	if err != nil {
+		t.Fatalf("Unexpected priv key error, %#v", err)
+	}
+
+	b64Signature, err := signEncodedPolicy(r, jsonPolicy, privKey, HashSHA256)
+	if err != nil {
+		t.Fatalf("Unexpected policy sign error, %#v", err)
+	}
+
+	hash := sha256.New()
+	if _, err = bytes.NewReader(jsonPolicy).WriteTo(hash); err != nil {
+		t.Fatalf("Unexpected hash error, %#v", err)
+	}
+
+	decodedSig, err := base64.StdEncoding.DecodeString(string(b64Signature))
+	if err != nil {
+		t.Fatalf("Unexpected base64 decode signature, %#v", err)
+	}
+
+	if err := rsa.VerifyPKCS1v15(&privKey.PublicKey, crypto.SHA256, hash.Sum(nil), decodedSig); err != nil {
+		t.Fatalf("Unable to verify signature, %#v", err)
+	}
+}
+
+func TestSignEncodedPolicyUnsupportedAlgorithm(t *testing.T) {
+	p := NewCannedPolicy("https://example.com/a", testTime)
+	_, jsonPolicy, err := encodePolicy(p)
+	if err != nil {
+		t.Fatalf("Unexpected policy encode error, %#v", err)
+	}
+
+	r := newRandomReader(rand.New(rand.NewSource(1)))
+	privKey, err := rsa.GenerateKey(r, 1024)
+	if err != nil {
+		t.Fatalf("Unexpected priv key error, %#v", err)
+	}
+
+	_, err = signEncodedPolicy(r, jsonPolicy, privKey, HashAlgorithm("MD5"))
+	if err == nil {
+		t.Fatal("Expected error for unsupported algorithm")
+	}
+	if !strings.Contains(err.Error(), "unsupported hash algorithm") {
+		t.Errorf("Expected unsupported hash algorithm error, got: %s", err.Error())
 	}
 }
 

--- a/feature/cloudfront/sign/sign_cookie.go
+++ b/feature/cloudfront/sign/sign_cookie.go
@@ -15,6 +15,8 @@ const (
 	CookieSignatureName = "CloudFront-Signature"
 	// CookieKeyIDName name of the signing Key ID cookie
 	CookieKeyIDName = "CloudFront-Key-Pair-Id"
+	// CookieHashAlgorithmName name of the hash algorithm cookie
+	CookieHashAlgorithmName = "CloudFront-Hash-Algorithm"
 )
 
 // A CookieOptions optional additional options that can be applied to the signed
@@ -58,6 +60,10 @@ type CookieSigner struct {
 	keyID  string
 	signer crypto.Signer
 
+	// HashAlg specifies the hash algorithm for signing. Defaults to
+	// HashSHA1. Set to HashSHA256 to produce SHA-256 signed cookies
+	// with a CloudFront-Hash-Algorithm cookie.
+	HashAlg HashAlgorithm
 	Opts CookieOptions
 }
 
@@ -125,7 +131,7 @@ func (s CookieSigner) Sign(u string, expires time.Time, opts ...func(*CookieOpti
 	}
 
 	p := NewCannedPolicy(resource, expires)
-	return createCookies(p, s.keyID, s.signer, s.Opts.apply(opts...))
+	return createCookies(p, s.keyID, s.signer, s.HashAlg, s.Opts.apply(opts...))
 }
 
 // Returns and validates the URL's scheme.
@@ -202,13 +208,13 @@ func cookieURLScheme(u string) (string, error) {
 //	    }
 //	}
 func (s CookieSigner) SignWithPolicy(p *Policy, opts ...func(*CookieOptions)) ([]*http.Cookie, error) {
-	return createCookies(p, s.keyID, s.signer, s.Opts.apply(opts...))
+	return createCookies(p, s.keyID, s.signer, s.HashAlg, s.Opts.apply(opts...))
 }
 
 // Prepares the cookies to be attached to the header. An (optional) options
 // struct is provided in case people don't want to manually edit their cookies.
-func createCookies(p *Policy, keyID string, signer crypto.Signer, opt CookieOptions) ([]*http.Cookie, error) {
-	b64Sig, b64Policy, err := p.Sign(signer)
+func createCookies(p *Policy, keyID string, signer crypto.Signer, hashAlg HashAlgorithm, opt CookieOptions) ([]*http.Cookie, error) {
+	b64Sig, b64Policy, err := p.SignWithHash(signer, hashAlg)
 	if err != nil {
 		return nil, err
 	}
@@ -234,6 +240,18 @@ func createCookies(p *Policy, keyID string, signer crypto.Signer, opt CookieOpti
 	}
 
 	cookies := []*http.Cookie{cPolicy, cSignature, cKey}
+
+	// Hash algorithm cookie is always appended when explicitly set. When
+	// HashAlg is empty (zero value), it defaults to SHA-1 without the
+	// cookie for backward compatibility.
+	if hashAlg != "" {
+		cookies = append(cookies, &http.Cookie{
+			Name:     CookieHashAlgorithmName,
+			Value:    string(hashAlg),
+			HttpOnly: true,
+			Expires:  opt.Expires,
+		})
+	}
 
 	// Applie the cookie options
 	for _, c := range cookies {

--- a/feature/cloudfront/sign/sign_cookie.go
+++ b/feature/cloudfront/sign/sign_cookie.go
@@ -64,7 +64,7 @@ type CookieSigner struct {
 	// HashSHA1. Set to HashSHA256 to produce SHA-256 signed cookies
 	// with a CloudFront-Hash-Algorithm cookie.
 	HashAlg HashAlgorithm
-	Opts CookieOptions
+	Opts    CookieOptions
 }
 
 // NewCookieSigner constructs and returns a new CookieSigner to be used to for
@@ -214,7 +214,7 @@ func (s CookieSigner) SignWithPolicy(p *Policy, opts ...func(*CookieOptions)) ([
 // Prepares the cookies to be attached to the header. An (optional) options
 // struct is provided in case people don't want to manually edit their cookies.
 func createCookies(p *Policy, keyID string, signer crypto.Signer, hashAlg HashAlgorithm, opt CookieOptions) ([]*http.Cookie, error) {
-	b64Sig, b64Policy, err := p.SignWithHash(signer, hashAlg)
+	b64Sig, b64Policy, err := p.SignWithAlgorithm(signer, hashAlg)
 	if err != nil {
 		return nil, err
 	}

--- a/feature/cloudfront/sign/sign_cookie_test.go
+++ b/feature/cloudfront/sign/sign_cookie_test.go
@@ -144,3 +144,45 @@ func TestSignCookie_ECDSA(t *testing.T) {
 		t.Errorf("expect %v, got %v", e, a)
 	}
 }
+
+
+func TestSignCookieSHA256(t *testing.T) {
+	privKey, err := rsa.GenerateKey(randReader, 1024)
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+
+	signer := NewCookieSigner("keyID", privKey)
+	signer.HashAlg = HashSHA256
+	cookies, err := signer.Sign("http*://*", time.Now().Add(1*time.Hour))
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+
+	if e, a := 4, len(cookies); e != a {
+		t.Fatalf("expect %v cookies, got %v", e, a)
+	}
+	if e, a := CookieHashAlgorithmName, cookies[3].Name; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "SHA256", cookies[3].Value; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+}
+
+func TestSignCookieSHA1NoHashCookie(t *testing.T) {
+	privKey, err := rsa.GenerateKey(randReader, 1024)
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+
+	signer := NewCookieSigner("keyID", privKey)
+	cookies, err := signer.Sign("http*://*", time.Now().Add(1*time.Hour))
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+
+	if e, a := 3, len(cookies); e != a {
+		t.Fatalf("expect %v cookies, got %v", e, a)
+	}
+}

--- a/feature/cloudfront/sign/sign_url.go
+++ b/feature/cloudfront/sign/sign_url.go
@@ -42,6 +42,10 @@ import (
 type URLSigner struct {
 	keyID  string
 	signer crypto.Signer
+
+	// HashAlg specifies the hash algorithm for signing. Defaults to
+	// SHA-1 when empty. Set to HashSHA256 for SHA-256 signed URLs.
+	HashAlg HashAlgorithm
 }
 
 // NewURLSigner constructs and returns a new URLSigner to be used to for signing
@@ -79,7 +83,7 @@ func (s URLSigner) Sign(url string, expires time.Time) (string, error) {
 		return "", err
 	}
 
-	return signURL(scheme, cleanedURL, s.keyID, NewCannedPolicy(resource, expires), false, s.signer)
+	return signURL(scheme, cleanedURL, s.keyID, NewCannedPolicy(resource, expires), false, s.signer, s.HashAlg)
 }
 
 // SignWithPolicy will sign a URL with the Policy provided.  The URL will be
@@ -123,22 +127,22 @@ func (s URLSigner) SignWithPolicy(url string, p *Policy) (string, error) {
 		return "", err
 	}
 
-	return signURL(scheme, cleanedURL, s.keyID, p, true, s.signer)
+	return signURL(scheme, cleanedURL, s.keyID, p, true, s.signer, s.HashAlg)
 }
 
-func signURL(scheme, url, keyID string, p *Policy, customPolicy bool, signer crypto.Signer) (string, error) {
+func signURL(scheme, url, keyID string, p *Policy, customPolicy bool, signer crypto.Signer, hashAlg HashAlgorithm) (string, error) {
 	// Validation URL elements
 	if err := validateURL(url); err != nil {
 		return "", err
 	}
 
-	b64Signature, b64Policy, err := p.Sign(signer)
+	b64Signature, b64Policy, err := p.SignWithHash(signer, hashAlg)
 	if err != nil {
 		return "", err
 	}
 
 	// build and return signed URL
-	builtURL := buildSignedURL(url, keyID, p, customPolicy, b64Policy, b64Signature)
+	builtURL := buildSignedURL(url, keyID, p, customPolicy, b64Policy, b64Signature, hashAlg)
 	if scheme == "rtmp" {
 		return buildRTMPURL(builtURL)
 	}
@@ -146,7 +150,7 @@ func signURL(scheme, url, keyID string, p *Policy, customPolicy bool, signer cry
 	return builtURL, nil
 }
 
-func buildSignedURL(baseURL, keyID string, p *Policy, customPolicy bool, b64Policy, b64Signature []byte) string {
+func buildSignedURL(baseURL, keyID string, p *Policy, customPolicy bool, b64Policy, b64Signature []byte, hashAlg HashAlgorithm) string {
 	pred := "?"
 	if strings.Contains(baseURL, "?") {
 		pred = "&"
@@ -159,6 +163,13 @@ func buildSignedURL(baseURL, keyID string, p *Policy, customPolicy bool, b64Poli
 		signedURL += fmt.Sprintf("Expires=%d", p.Statements[0].Condition.DateLessThan.UTC().Unix())
 	}
 	signedURL += fmt.Sprintf("&Signature=%s&Key-Pair-Id=%s", string(b64Signature), keyID)
+
+	// Hash-Algorithm is always appended when explicitly set. When HashAlg
+	// is empty (zero value), it defaults to SHA-1 without the parameter
+	// for backward compatibility.
+	if hashAlg != "" {
+		signedURL += "&Hash-Algorithm=" + string(hashAlg)
+	}
 
 	return signedURL
 }

--- a/feature/cloudfront/sign/sign_url.go
+++ b/feature/cloudfront/sign/sign_url.go
@@ -136,7 +136,7 @@ func signURL(scheme, url, keyID string, p *Policy, customPolicy bool, signer cry
 		return "", err
 	}
 
-	b64Signature, b64Policy, err := p.SignWithHash(signer, hashAlg)
+	b64Signature, b64Policy, err := p.SignWithAlgorithm(signer, hashAlg)
 	if err != nil {
 		return "", err
 	}

--- a/feature/cloudfront/sign/sign_url_test.go
+++ b/feature/cloudfront/sign/sign_url_test.go
@@ -113,10 +113,62 @@ var testBuildSignedURL = []struct {
 
 func TestBuildSignedURL(t *testing.T) {
 	for i, v := range testBuildSignedURL {
-		u := buildSignedURL(v.u, v.keyID, v.p, v.customPolicy, v.b64Policy, v.b64Sig)
+		u := buildSignedURL(v.u, v.keyID, v.p, v.customPolicy, v.b64Policy, v.b64Sig, "")
 		if u != v.out {
 			t.Errorf("%d, Unexpected URL\nexpect: %s\nactual: %s\n", i, v.out, u)
 		}
+	}
+}
+
+func TestSignURLSHA256(t *testing.T) {
+	privKey := unit.RSAPrivateKey
+	s := NewURLSigner("KeyID", privKey)
+	s.HashAlg = HashSHA256
+
+	u, err := s.Sign("http://example.com/a", testSignTime)
+	if err != nil {
+		t.Fatalf("Unexpected error, %s", err.Error())
+	}
+
+	if !strings.HasSuffix(u, "&Hash-Algorithm=SHA256") {
+		t.Errorf("Expected URL to end with &Hash-Algorithm=SHA256, got: %s", u)
+	}
+}
+
+func TestSignURLSHA1Explicit(t *testing.T) {
+	privKey := unit.RSAPrivateKey
+	s := NewURLSigner("KeyID", privKey)
+	s.HashAlg = HashSHA1
+
+	u, err := s.Sign("http://example.com/a", testSignTime)
+	if err != nil {
+		t.Fatalf("Unexpected error, %s", err.Error())
+	}
+
+	if !strings.HasSuffix(u, "&Hash-Algorithm=SHA1") {
+		t.Errorf("Expected URL to end with &Hash-Algorithm=SHA1, got: %s", u)
+	}
+}
+
+func TestSignURLDefaultNoHashParam(t *testing.T) {
+	privKey := unit.RSAPrivateKey
+	s := NewURLSigner("KeyID", privKey)
+
+	u, err := s.Sign("http://example.com/a", testSignTime)
+	if err != nil {
+		t.Fatalf("Unexpected error, %s", err.Error())
+	}
+
+	if strings.Contains(u, "Hash-Algorithm") {
+		t.Errorf("Expected no Hash-Algorithm param for default signer, got: %s", u)
+	}
+}
+
+func TestBuildSignedURLSHA256(t *testing.T) {
+	u := buildSignedURL("https://example.com/a", "KeyID", NewCannedPolicy("", testSignTime), false, []byte("b64Policy"), []byte("b64Sig"), HashSHA256)
+	expect := "https://example.com/a?Expires=1257894000&Signature=b64Sig&Key-Pair-Id=KeyID&Hash-Algorithm=SHA256"
+	if u != expect {
+		t.Errorf("Unexpected URL\nexpect: %s\nactual: %s\n", expect, u)
 	}
 }
 


### PR DESCRIPTION
CloudFront supports SHA-256 as of April 2026 https://aws.amazon.com/about-aws/whats-new/2026/04/amazon-cloudfront-sha-256-signed-urls/

We add support for CloudFront signing via customization, so extending it to support SHA-256 as another algorithm to use by adding `SignWithAlgorithm` function. Existing `Sign` uses SHA-1 and not providing an algorithm defaults to SHA-1, so existing users won't be impacted by this.

There's no guidance from CloudFront about this being preferred over SHA-1, so not marking any existing functions as deprecated or on path to deprecation, or marking any preference between one or the other.

This was verified on a similar fashion as a previous PR https://github.com/aws/aws-sdk-go-v2/pull/3325#issuecomment-4346692263 

This closes #3373