### PR TITLE
Feat discover endpoint partition validation

### DIFF
--- a/.changelog/3154470df97d4f7e83dc11463ef5a4c3.json
+++ b/.changelog/3154470df97d4f7e83dc11463ef5a4c3.json
@@ -1,0 +1,8 @@
+{
+    "id": "3154470d-f97d-4f7e-83dc-11463ef5a4c3",
+    "type": "feature",
+    "description": "Validate discovered endpoint before overwriting request host in case cached tampered endpoints pollute request",
+    "modules": [
+        "service/internal/endpoint-discovery"
+    ]
+}

--- a/service/internal/endpoint-discovery/middleware.go
+++ b/service/internal/endpoint-discovery/middleware.go
@@ -3,9 +3,11 @@ package endpointdiscovery
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsmiddleware "github.com/aws/aws-sdk-go-v2/aws/middleware"
+	"github.com/aws/aws-sdk-go-v2/internal/endpoints/awsrulesfn"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 
 	"github.com/aws/smithy-go/logging"
@@ -94,8 +96,13 @@ func (d *DiscoverEndpoint) HandleFinalize(
 	}
 
 	if weightedAddress.URL != nil {
-		// we only want the host, normal endpoint resolution can include path/query
-		req.URL.Host = weightedAddress.URL.Host
+		// we only want the host, normal endpoint resolution can include path/query, the host must be
+		// validated before override to make sure its dns suffix is within the partition of
+		host := weightedAddress.URL.Host
+		partitionCfg := awsrulesfn.GetPartition(d.Region)
+		if partitionCfg != nil && (strings.HasSuffix(host, "."+partitionCfg.DnsSuffix) || strings.HasSuffix(host, "."+partitionCfg.DualStackDnsSuffix)) {
+			req.URL.Host = weightedAddress.URL.Host
+		}
 	}
 
 	return next.HandleFinalize(ctx, in)

--- a/service/internal/endpoint-discovery/middleware_test.go
+++ b/service/internal/endpoint-discovery/middleware_test.go
@@ -1,0 +1,102 @@
+package endpointdiscovery
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/smithy-go/middleware"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
+)
+
+func Test_Discover_Endpoint(t *testing.T) {
+	cases := map[string]struct {
+		region      string
+		requestHost string
+		address     WeightedAddress
+		expectHost  string
+	}{
+		"endpoint overwritten by discovered value with valid dns suffix": {
+			region:      "cn-north-1",
+			requestHost: "initialhost.amazonaws.com.cn",
+			address: WeightedAddress{
+				URL: &url.URL{
+					Host: "cachedep.amazonaws.com.cn",
+				},
+			},
+			expectHost: "cachedep.amazonaws.com.cn",
+		},
+		"endpoint overwritten by discovered value with valid dual stack dns suffix": {
+			region:      "us-east-1",
+			requestHost: "initialhost.amazonaws.com",
+			address: WeightedAddress{
+				URL: &url.URL{
+					Host: "cachedep.api.aws",
+				},
+			},
+			expectHost: "cachedep.api.aws",
+		},
+		"discover endpoint omitted due to out of bound partition suffix": {
+			region:      "us-east-1",
+			requestHost: "initialhost.amazonaws.com",
+			address: WeightedAddress{
+				URL: &url.URL{
+					Host: "cachedep.amazonaws.com.cn",
+				},
+			},
+			expectHost: "initialhost.amazonaws.com",
+		},
+		"discover endpoint omitted due to invalid partition suffix": {
+			region:      "us-east-1",
+			requestHost: "initialhost.amazonaws.com",
+			address: WeightedAddress{
+				URL: &url.URL{
+					Host: "cachedep.invalidamazonaws.com",
+				},
+			},
+			expectHost: "initialhost.amazonaws.com",
+		},
+		"nil endpoint discovered and omitted": {
+			region:      "us-east-1",
+			requestHost: "initialhost.amazonaws.com",
+			address:     WeightedAddress{},
+			expectHost:  "initialhost.amazonaws.com",
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			d := &DiscoverEndpoint{
+				DiscoverOperation: func(ctx context.Context, region string, options ...func(*DiscoverEndpointOptions)) (WeightedAddress, error) {
+					return c.address, nil
+				},
+				EndpointDiscoveryEnableState: aws.EndpointDiscoveryEnabled,
+				Region:                       c.region,
+			}
+			_, _, err := d.HandleFinalize(context.TODO(), middleware.FinalizeInput{
+				Request: &smithyhttp.Request{
+					Request: &http.Request{
+						URL: &url.URL{
+							Host: c.requestHost,
+						},
+					},
+				},
+			}, middleware.FinalizeHandlerFunc(func(ctx context.Context, in middleware.FinalizeInput) (out middleware.FinalizeOutput, metadata middleware.Metadata, error error) {
+				req, ok := in.Request.(*smithyhttp.Request)
+				if !ok {
+					t.Fatal("invalid request type")
+				}
+				if e, a := c.expectHost, req.URL.Host; e != a {
+					t.Errorf("expected host %s, got %s", e, a)
+				}
+				return
+			}))
+
+			if err != nil {
+				t.Fatalf("expect no error, got %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds a validation before any discovered endpoint overwrite to make sure the cached value is still under the region's aws partitions, if not, the current request's host will be respected 
