### PR TITLE
chore: harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -25,9 +25,10 @@ jobs:
     env:
       JAVA_TOOL_OPTIONS: "-Xmx2g"
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       with:
         fetch-depth: 0
+        persist-credentials: false
 
     - name: Download Coretto 17 JDK
       run: |
@@ -35,14 +36,14 @@ jobs:
         wget -O $RUNNER_TEMP/java_package.tar.gz $download_url
 
     - name: Set up Coretto 17 JDK
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@91d3aa4956ec4a53e477c4907347b5e3481be8c9 # v2
       with:
         distribution: 'jdkfile'
         jdkFile: ${{ runner.temp }}/java_package.tar.gz
         java-version: 17
         architecture: x64
 
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2
       with:
         go-version: ${{ matrix.go-version }}
 
@@ -61,4 +62,3 @@ jobs:
 
     - name: SDK Codegen
       run: make smithy-generate
-

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,10 +27,12 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         go-version: ["1.24", "1.25", "1.26"]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+      with:
+        persist-credentials: false
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2
       with:
         go-version: ${{ matrix.go-version }}
 
@@ -55,10 +57,12 @@ jobs:
     env:
       GOARCH: "386"
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+      with:
+        persist-credentials: false
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2
       with:
         go-version: ${{ matrix.go-version }}
 
@@ -83,10 +87,12 @@ jobs:
     env:
       EACHMODULE_SKIP: "internal\\repotools\\changes"
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+      with:
+        persist-credentials: false
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2
       with:
         go-version: ${{ matrix.go-version }}
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -22,13 +22,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           role-to-assume: ${{ secrets.CI_AWS_ROLE_ARN }}
           aws-region: us-west-2
       - name: Run tests
         id: integration-tests
-        uses: aws-actions/aws-codebuild-run-build@v1
+        uses: aws-actions/aws-codebuild-run-build@7e46c3fa1c1f217e26a73712796b1f78938b534b # v1
         with:
           project-name: aws-sdk-go-v2-integrationtests
       - name: Cancel tests
@@ -40,4 +40,3 @@ jobs:
             echo "aws codebuild stop-build --id $BUILD_ID"
             aws codebuild stop-build --id $BUILD_ID
           fi
-

--- a/.github/workflows/issue-regression-labeler.yml
+++ b/.github/workflows/issue-regression-labeler.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Fetch template body
         id: check_regression
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TEMPLATE_BODY: ${{ github.event.issue.body }}
@@ -24,8 +24,9 @@ jobs:
       - name: Manage regression label
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          STEPS_CHECK_REGRESSION_OUTPUTS_IS_REGRESSION: ${{ steps.check_regression.outputs.is_regression }}
         run: |
-          if [ "${{ steps.check_regression.outputs.is_regression }}" == "true" ]; then
+          if [ "${STEPS_CHECK_REGRESSION_OUTPUTS_IS_REGRESSION}" == "true" ]; then
             gh issue edit ${{ github.event.issue.number }} --add-label "potential-regression" -R ${{ github.repository }}
           else
             gh issue edit ${{ github.event.issue.number }} --remove-label "potential-regression" -R ${{ github.repository }}

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -16,27 +16,30 @@ jobs:
 
     steps:
       - name: Checkout target
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           path: sdkbase
           ref: ${{ github.base_ref }}
+          persist-credentials: false
       - name: Checkout this ref
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           path: new-ref
           fetch-depth: 0
+          persist-credentials: false
       - name: Get Diff
         run: git --git-dir ./new-ref/.git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }} ${{ github.sha }} > refDiffFiles.txt
       - name: Get Target Files
         run: git --git-dir ./sdkbase/.git ls-files | grep -xf refDiffFiles.txt - > targetFiles.txt
       - name: Checkout scancode
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           repository: nexB/scancode-toolkit
           path: scancode-toolkit
           fetch-depth: 1
+          persist-credentials: false
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2
         with:
           python-version: ${{ matrix.python-version }}
       # ScanCode

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -29,10 +29,12 @@ jobs:
     env:
       EACHMODULE_SKIP: "internal"
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+      with:
+        persist-credentials: false
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2
       with:
         go-version: ${{ matrix.go-version }}
 


### PR DESCRIPTION
> [!NOTE]
> Some actions may be pinned to versions that are not the latest available. This PR intentionally preserves the currently used compatible versions where possible. The scope is to make action references immutable and address the zizmor findings, not to upgrade actions to their latest releases.

## Overview

This PR hardens GitHub Actions configuration for `aws-sdk-go-v2` to resolve zizmor findings around action pinning, credential persistence, and shell template expansion.

## Summary

- Pins GitHub Actions `uses:` references to full commit SHAs while retaining version comments for readability.
- Uses commit SHAs resolved from the existing action version tags instead of pinning moving tags or branches.
- Sets `persist-credentials: false` for checkout steps that do not need persisted Git credentials.
- Moves the regression-label check output into an environment variable before using it in the shell `run:` block.