### PR TITLE
Unset SMITHY_GO_BUILD_API on protocol tests generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ smithy-generate:
 	cd codegen && ./gradlew clean build -Plog-tests && ./gradlew clean
 
 smithy-generate-protocol-tests:
-	cd codegen && ./gradlew :protocol-test-codegen:build -Plog-tests && ./gradlew :protocol-test-codegen:clean
+	cd codegen && SMITHY_GO_BUILD_API= ./gradlew :protocol-test-codegen:build -Plog-tests && ./gradlew :protocol-test-codegen:clean
 
 # suffix-to-path pattern
 # Targets with pattern suffix -% convert the suffix to a path by:


### PR DESCRIPTION
The GoCodegenPlugin on smithy-go reads `SMITHY_GO_BUILD_API`I and skips any service that doesn't start with the prefix [reference](https://github.com/aws/smithy-go/blob/main/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoCodegenPlugin.java#L37) 

Now that we always re-generate ALL protocol tests, if this env variable is set, we skip codegen (since no service matched the target) but we ALSO remove the whole directory, so we fail later on when we try to regenerate snapshot tests. 

Given that protocol tests are now fully regenerated every time, we should unset this variable to ensure they are always recreated.
