### PR TITLE
Add replace for credentials dependency added on go.mod

### DIFF
--- a/internal/protocoltest/awsrestjson/go.mod
+++ b/internal/protocoltest/awsrestjson/go.mod
@@ -15,6 +15,8 @@ replace github.com/aws/aws-sdk-go-v2 => ../../../
 
 replace github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream => ../../../aws/protocol/eventstream/
 
+replace github.com/aws/aws-sdk-go-v2/credentials => ../../../credentials/
+
 replace github.com/aws/aws-sdk-go-v2/internal/configsources => ../../../internal/configsources/
 
 replace github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 => ../../../internal/endpoints/v2/


### PR DESCRIPTION
Doing the same pattern as we have on other test in protocoltest. This dependency was added when we added protocol tests #3412