### PR TITLE
Feat tmv2 parity

### DIFF
--- a/.changelog/189eed4b1c5b4c38b00b1f7d3795c3ba.json
+++ b/.changelog/189eed4b1c5b4c38b00b1f7d3795c3ba.json
@@ -1,0 +1,8 @@
+{
+    "id": "189eed4b-1c5b-4c38-b00b-1f7d3795c3ba",
+    "type": "bugfix",
+    "description": "Feature parity for transfer manager v2 to allow range download, support full object checksum type, fix error from failed multipart upload clean up due to ctx cancellation, honor mpu threshold and add back max upload parts option",
+    "modules": [
+        "feature/s3/transfermanager"
+    ]
+}

--- a/.changelog/189eed4b1c5b4c38b00b1f7d3795c3ba.json
+++ b/.changelog/189eed4b1c5b4c38b00b1f7d3795c3ba.json
@@ -1,7 +1,7 @@
 {
     "id": "189eed4b-1c5b-4c38-b00b-1f7d3795c3ba",
     "type": "bugfix",
-    "description": "Feature parity for transfer manager v2 to allow range download, support checksum type config, fix error from failed multipart upload clean up due to ctx cancellation, honor mpu threshold and add back max upload parts option",
+    "description": "Feature parity for transfer manager v2 to allow range download, support checksum type config, fix error from failed transfer's follow-up due to ctx cancellation, honor mpu threshold and add back max upload parts option",
     "modules": [
         "feature/s3/transfermanager"
     ]

--- a/.changelog/189eed4b1c5b4c38b00b1f7d3795c3ba.json
+++ b/.changelog/189eed4b1c5b4c38b00b1f7d3795c3ba.json
@@ -1,7 +1,7 @@
 {
     "id": "189eed4b-1c5b-4c38-b00b-1f7d3795c3ba",
     "type": "bugfix",
-    "description": "Feature parity for transfer manager v2 to allow range download, support full object checksum type, fix error from failed multipart upload clean up due to ctx cancellation, honor mpu threshold and add back max upload parts option",
+    "description": "Feature parity for transfer manager v2 to allow range download, support checksum type config, fix error from failed multipart upload clean up due to ctx cancellation, honor mpu threshold and add back max upload parts option",
     "modules": [
         "feature/s3/transfermanager"
     ]

--- a/feature/s3/transfermanager/api_client.go
+++ b/feature/s3/transfermanager/api_client.go
@@ -44,6 +44,7 @@ func New(s3Client S3APIClient, optFns ...func(*Options)) *Client {
 	resolveGetObjectType(&opts)
 	resolvePartBodyMaxRetries(&opts)
 	resolveGetBufferSize(&opts)
+	resolveMaxUploadParts(&opts)
 
 	return &Client{
 		options: opts,

--- a/feature/s3/transfermanager/api_op_DownloadDirectory.go
+++ b/feature/s3/transfermanager/api_op_DownloadDirectory.go
@@ -197,7 +197,9 @@ func (d *directoryDownloader) downloadDirectory(ctx context.Context) (*DownloadD
 	d.wg.Wait()
 
 	if d.err != nil {
-		d.emitter.Failed(ctx, d.in, d.err)
+		freshCtx, cancel := d.freshContext(ctx)
+		defer cancel()
+		d.emitter.Failed(freshCtx, d.in, d.err)
 		return nil, d.err
 	}
 
@@ -308,6 +310,13 @@ func (d *directoryDownloader) downloadObject(ctx context.Context, ch chan object
 		d.objectsDownloaded.Add(1)
 		d.emitter.ObjectsTransferred(ctx, n)
 	}
+}
+
+func (d *directoryDownloader) freshContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	if d.options.FailTimeout <= 0 {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(context.Background(), d.options.FailTimeout)
 }
 
 func (d *directoryDownloader) setErr(err error) {

--- a/feature/s3/transfermanager/api_op_DownloadObject.go
+++ b/feature/s3/transfermanager/api_op_DownloadObject.go
@@ -580,7 +580,9 @@ func (d *downloader) download(ctx context.Context) (*DownloadObjectOutput, error
 	if d.options.GetObjectType == types.GetObjectParts {
 		output = d.getChunk(ctx, 1, "", clientOptions...)
 		if d.err != nil {
-			d.emitter.Failed(ctx, d.err)
+			freshCtx, cancel := d.freshContext(ctx)
+			defer cancel()
+			d.emitter.Failed(freshCtx, d.err)
 			return output, d.err
 		}
 
@@ -608,7 +610,9 @@ func (d *downloader) download(ctx context.Context) (*DownloadObjectOutput, error
 		if rng := aws.ToString(d.in.Range); rng != "" {
 			rangeStart, rangeEnd, err := getReqRange(rng)
 			if err != nil {
-				d.emitter.Failed(ctx, d.err)
+				freshCtx, cancel := d.freshContext(ctx)
+				defer cancel()
+				d.emitter.Failed(freshCtx, d.err)
 				return nil, err
 			}
 			d.offset = rangeStart
@@ -631,7 +635,9 @@ func (d *downloader) download(ctx context.Context) (*DownloadObjectOutput, error
 					return out, nil
 				}
 			}
-			d.emitter.Failed(ctx, d.err)
+			freshCtx, cancel := d.freshContext(ctx)
+			defer cancel()
+			d.emitter.Failed(freshCtx, d.err)
 			return nil, d.err
 		}
 		total := d.totalBytes
@@ -659,7 +665,9 @@ func (d *downloader) download(ctx context.Context) (*DownloadObjectOutput, error
 	}
 
 	if d.err != nil {
-		d.emitter.Failed(ctx, d.err)
+		freshCtx, cancel := d.freshContext(ctx)
+		defer cancel()
+		d.emitter.Failed(freshCtx, d.err)
 		return nil, d.err
 	}
 
@@ -833,6 +841,13 @@ func (d *downloader) setTotalBytes(resp *s3.GetObjectOutput) {
 
 		d.totalBytes = total
 	}
+}
+
+func (d *downloader) freshContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	if d.options.FailTimeout <= 0 {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(context.Background(), d.options.FailTimeout)
 }
 
 func (d *downloader) setOutput(resp *DownloadObjectOutput) {

--- a/feature/s3/transfermanager/api_op_DownloadObject.go
+++ b/feature/s3/transfermanager/api_op_DownloadObject.go
@@ -100,6 +100,9 @@ type DownloadObjectInput struct {
 	// [RFC 7232]: https://tools.ietf.org/html/rfc7232
 	IfUnmodifiedSince *time.Time
 
+	// Downloads the specified byte range of an object. This field only applies when GetObjectType is GetObjectRanges
+	Range *string
+
 	// Confirms that the requester knows that they will be charged for the request.
 	// Bucket owners need not specify this parameter in their requests. If either the
 	// source or destination S3 bucket has Requester Pays enabled, the requester will
@@ -602,6 +605,16 @@ func (d *downloader) download(ctx context.Context) (*DownloadObjectOutput, error
 			d.wg.Wait()
 		}
 	} else {
+		if rng := aws.ToString(d.in.Range); rng != "" {
+			rangeStart, rangeEnd, err := getReqRange(rng)
+			if err != nil {
+				d.emitter.Failed(ctx, d.err)
+				return nil, err
+			}
+			d.offset = rangeStart
+			d.totalBytes = rangeEnd + 1
+			d.pos = rangeStart
+		}
 		d.getChunk(ctx, 0, d.byteRange(), clientOptions...)
 		if d.err != nil {
 			// early check to see if error is caused by range download a zero object
@@ -780,7 +793,7 @@ func (d *downloader) tryDownloadChunk(ctx context.Context, params *s3.GetObjectI
 
 	d.totalBytesOnce.Do(func() {
 		d.setTotalBytes(out)
-		d.emitter.Start(ctx, d.in, d.totalBytes)
+		d.emitter.Start(ctx, d.in, d.totalBytes-d.offset)
 	}) // Set total in first GET
 
 	var n int64
@@ -843,14 +856,22 @@ func (d *downloader) byteRange() string {
 
 func getReqRange(rng string) (int64, int64, error) {
 	// rng fmt "bytes=start-end"
-	ranges := strings.Split(strings.Split(rng, "=")[1], "-")
-	start, err := strconv.ParseInt(ranges[0], 10, 64)
-	if err != nil {
-		return 0, 0, fmt.Errorf("error when parsing request start: %v", err)
+	sub1 := strings.Split(rng, "=")
+	if len(sub1) != 2 {
+		return -1, -1, fmt.Errorf("invalid range format %s, should be bytes=start-end format", rng)
 	}
-	end, err := strconv.ParseInt(ranges[1], 10, 64)
+	sub2 := strings.Split(sub1[1], "-")
+	if len(sub2) != 2 {
+		return -1, -1, fmt.Errorf("invalid range format %s, should be bytes=start-end format", rng)
+	}
+
+	start, err := strconv.ParseInt(sub2[0], 10, 64)
 	if err != nil {
-		return 0, 0, fmt.Errorf("error when parsing request end: %v", err)
+		return -1, -1, fmt.Errorf("invalid range start %v", err)
+	}
+	end, err := strconv.ParseInt(sub2[1], 10, 64)
+	if err != nil {
+		return -1, -1, fmt.Errorf("invalid range end %v", err)
 	}
 	return start, end, nil
 }

--- a/feature/s3/transfermanager/api_op_DownloadObject.go
+++ b/feature/s3/transfermanager/api_op_DownloadObject.go
@@ -871,20 +871,20 @@ func (d *downloader) byteRange() string {
 
 func getReqRange(rng string) (int64, int64, error) {
 	// rng fmt "bytes=start-end"
-	sub1 := strings.Split(rng, "=")
-	if len(sub1) != 2 {
+	rangeFmt := strings.Split(rng, "=")
+	if len(rangeFmt) != 2 {
 		return -1, -1, fmt.Errorf("invalid range format %s, should be bytes=start-end format", rng)
 	}
-	sub2 := strings.Split(sub1[1], "-")
-	if len(sub2) != 2 {
+	startEnd := strings.Split(rangeFmt[1], "-")
+	if len(startEnd) != 2 {
 		return -1, -1, fmt.Errorf("invalid range format %s, should be bytes=start-end format", rng)
 	}
 
-	start, err := strconv.ParseInt(sub2[0], 10, 64)
+	start, err := strconv.ParseInt(startEnd[0], 10, 64)
 	if err != nil {
 		return -1, -1, fmt.Errorf("invalid range start %v", err)
 	}
-	end, err := strconv.ParseInt(sub2[1], 10, 64)
+	end, err := strconv.ParseInt(startEnd[1], 10, 64)
 	if err != nil {
 		return -1, -1, fmt.Errorf("invalid range end %v", err)
 	}

--- a/feature/s3/transfermanager/api_op_DownloadObject_integ_test.go
+++ b/feature/s3/transfermanager/api_op_DownloadObject_integ_test.go
@@ -4,9 +4,10 @@ package transfermanager
 
 import (
 	"bytes"
-	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager/types"
 	"strings"
 	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager/types"
 )
 
 func TestInteg_DownloadObject(t *testing.T) {
@@ -35,6 +36,16 @@ func TestInteg_DownloadObject(t *testing.T) {
 		"range get multipart body": {
 			Body:       bytes.NewReader(largeObjectBuf),
 			ExpectBody: largeObjectBuf,
+			OptFns: []func(*Options){
+				func(opt *Options) {
+					opt.GetObjectType = types.GetObjectRanges
+				},
+			},
+		},
+		"range get large object body with range input": {
+			Body:       bytes.NewReader(largeObjectBuf),
+			ExpectBody: largeObjectBuf[1:10485761],
+			Range:      "bytes=1-10485760",
 			OptFns: []func(*Options){
 				func(opt *Options) {
 					opt.GetObjectType = types.GetObjectRanges

--- a/feature/s3/transfermanager/api_op_GetObject.go
+++ b/feature/s3/transfermanager/api_op_GetObject.go
@@ -109,6 +109,9 @@ type GetObjectInput struct {
 	// [RFC 7232]: https://tools.ietf.org/html/rfc7232
 	IfUnmodifiedSince *time.Time
 
+	// Downloads the specified byte range of an object. This field only applies when GetObjectType is GetObjectRanges
+	Range *string
+
 	// Confirms that the requester knows that they will be charged for the request.
 	// Bucket owners need not specify this parameter in their requests. If either the
 	// source or destination S3 bucket has Requester Pays enabled, the requester will
@@ -658,12 +661,21 @@ func (g *getter) get(ctx context.Context) (out *GetObjectOutput, err error) {
 		if aws.ToInt64(out.ContentLength) == 0 {
 			return g.singleDownload(ctx, clientOptions...)
 		}
+
 		total := aws.ToInt64(out.ContentLength)
-		contentLength := total
+		if rng := aws.ToString(g.in.Range); rng != "" {
+			r.pos, total, err = getReqRange(rng)
+			total++
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		contentLength := total - r.pos
 
 		output.mapFromHeadObjectOutput(out, g.in.ChecksumMode, !g.options.DisableChecksumValidation, r)
 		output.ContentLength = aws.Int64(contentLength)
-		output.ContentRange = aws.String(fmt.Sprintf("bytes=0-%d/%d", total-1, aws.ToInt64(out.ContentLength)))
+		output.ContentRange = aws.String(fmt.Sprintf("bytes=%d-%d/%d", r.pos, total-1, aws.ToInt64(out.ContentLength)))
 
 		partsCount := int32((contentLength-1)/g.options.PartSizeBytes + 1)
 		sectionParts := int32(max(1, g.options.GetObjectBufferSize/g.options.PartSizeBytes))

--- a/feature/s3/transfermanager/api_op_GetObject_integ_test.go
+++ b/feature/s3/transfermanager/api_op_GetObject_integ_test.go
@@ -4,9 +4,10 @@ package transfermanager
 
 import (
 	"bytes"
-	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager/types"
 	"strings"
 	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager/types"
 )
 
 func TestInteg_GetObject(t *testing.T) {
@@ -35,6 +36,16 @@ func TestInteg_GetObject(t *testing.T) {
 		"range get multipart body": {
 			Body:       bytes.NewReader(largeObjectBuf),
 			ExpectBody: largeObjectBuf,
+			OptFns: []func(*Options){
+				func(opt *Options) {
+					opt.GetObjectType = types.GetObjectRanges
+				},
+			},
+		},
+		"range get multipart body with range input": {
+			Body:       bytes.NewReader(largeObjectBuf),
+			Range:      "bytes=8388608-16777215",
+			ExpectBody: largeObjectBuf[8388608:16777216],
 			OptFns: []func(*Options){
 				func(opt *Options) {
 					opt.GetObjectType = types.GetObjectRanges

--- a/feature/s3/transfermanager/api_op_PutObject_integ_test.go
+++ b/feature/s3/transfermanager/api_op_PutObject_integ_test.go
@@ -6,6 +6,8 @@ import (
 	"bytes"
 	"strings"
 	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager/types"
 )
 
 func TestInteg_PutObject(t *testing.T) {
@@ -13,6 +15,12 @@ func TestInteg_PutObject(t *testing.T) {
 		"seekable body":         {Body: strings.NewReader("hello world"), ExpectBody: []byte("hello world")},
 		"empty string body":     {Body: strings.NewReader(""), ExpectBody: []byte("")},
 		"multipart upload body": {Body: bytes.NewReader(largeObjectBuf), ExpectBody: largeObjectBuf},
+		"multipart upload body with full object checksum type": {
+			Body:              bytes.NewReader(largeObjectBuf),
+			ExpectBody:        largeObjectBuf,
+			ChecksumAlgorithm: types.ChecksumAlgorithmCrc32c, // only CRC algorithms support full object checksum
+			ChecksumType:      types.ChecksumTypeFullObject,
+		},
 	}
 
 	for name, c := range cases {

--- a/feature/s3/transfermanager/api_op_PutObject_integ_test.go
+++ b/feature/s3/transfermanager/api_op_PutObject_integ_test.go
@@ -18,7 +18,7 @@ func TestInteg_PutObject(t *testing.T) {
 		"multipart upload body with full object checksum type": {
 			Body:              bytes.NewReader(largeObjectBuf),
 			ExpectBody:        largeObjectBuf,
-			ChecksumAlgorithm: types.ChecksumAlgorithmCrc32c, // only CRC algorithms support full object checksum
+			ChecksumAlgorithm: types.ChecksumAlgorithmCrc32c,
 			ChecksumType:      types.ChecksumTypeFullObject,
 		},
 	}

--- a/feature/s3/transfermanager/api_op_UploadDirectory.go
+++ b/feature/s3/transfermanager/api_op_UploadDirectory.go
@@ -195,7 +195,9 @@ func (u *directoryUploader) uploadDirectory(ctx context.Context) (*UploadDirecto
 	u.wg.Wait()
 
 	if u.err != nil {
-		u.emitter.Failed(ctx, u.in, u.err)
+		freshCtx, cancel := u.freshContext(ctx)
+		defer cancel()
+		u.emitter.Failed(freshCtx, u.in, u.err)
 		return nil, u.err
 	}
 
@@ -390,6 +392,13 @@ func (u *directoryUploader) uploadFile(ctx context.Context, ch chan fileEntry) {
 		u.filesUploaded.Add(1)
 		u.emitter.ObjectsTransferred(ctx, aws.ToInt64(out.ContentLength))
 	}
+}
+
+func (u *directoryUploader) freshContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	if u.options.FailTimeout <= 0 {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(context.Background(), u.options.FailTimeout)
 }
 
 func (u *directoryUploader) setErr(err error) {

--- a/feature/s3/transfermanager/api_op_UploadObject.go
+++ b/feature/s3/transfermanager/api_op_UploadObject.go
@@ -888,12 +888,15 @@ func (u *uploader) initSize() error {
 		}
 	}
 
+	if u.options.MaxUploadParts <= 0 || u.options.MaxUploadParts > defaultMaxUploadParts {
+		return fmt.Errorf("max upload parts must be greater than 0 and less than %d", defaultMaxUploadParts)
+	}
 	// Try to adjust partSize if it is too small and account for
 	// integer division truncation.
-	if u.objectSize/u.options.PartSizeBytes >= int64(defaultMaxUploadParts) {
+	if u.objectSize/u.options.PartSizeBytes >= u.options.MaxUploadParts {
 		// Add one to the part size to account for remainders
 		// during the size calculation. e.g odd number of bytes.
-		u.options.PartSizeBytes = (u.objectSize / int64(defaultMaxUploadParts)) + 1
+		u.options.PartSizeBytes = u.objectSize/u.options.MaxUploadParts + 1
 	}
 	return nil
 }
@@ -910,7 +913,9 @@ func (u *uploader) singleUpload(ctx context.Context, r io.Reader, sz int, cleanU
 	u.progressEmitter.Start(ctx, u.in, objectSize)
 	out, err := u.options.S3.PutObject(ctx, params, opts...)
 	if err != nil {
-		u.progressEmitter.Failed(ctx, err)
+		freshCtx, cancel := u.freshContext(ctx)
+		defer cancel()
+		u.progressEmitter.Failed(freshCtx, err)
 		return nil, err
 	}
 
@@ -928,16 +933,27 @@ func (u *uploader) nextReader(ctx context.Context) (io.Reader, int, func(), erro
 	if !u.multipleRead {
 		u.multipleRead = true
 		// read first part up to a maximum of PartSize to avoid allocating 8MB buffer out of the gate
-		r := io.LimitReader(u.in.Body, u.options.PartSizeBytes)
+		r := io.LimitReader(u.in.Body, u.options.MultipartUploadThreshold)
 		firstPart, err := io.ReadAll(r)
 		if err != nil {
 			return nil, 0, func() {}, err
 		}
 		n := len(firstPart)
-		if int64(n) < u.options.PartSizeBytes {
+		if int64(n) < u.options.MultipartUploadThreshold {
 			return bytes.NewReader(firstPart), n, func() {}, io.EOF
 		}
-		return bytes.NewReader(firstPart), n, func() {}, nil
+		if int64(n) > u.options.PartSizeBytes {
+			u.in.Body = io.MultiReader(bytes.NewReader(firstPart[u.options.PartSizeBytes:]), u.in.Body)
+			return bytes.NewReader(firstPart[:u.options.PartSizeBytes]), int(u.options.PartSizeBytes), func() {}, nil
+		}
+		remainedBytes := u.options.PartSizeBytes - int64(n)
+		r = io.LimitReader(u.in.Body, remainedBytes)
+		remainedPart, err := io.ReadAll(r)
+		if err != nil {
+			return nil, 0, func() {}, err
+		}
+		firstPart = append(firstPart, remainedPart...)
+		return bytes.NewReader(firstPart), len(firstPart), func() {}, nil
 	}
 	part, err := u.partPool.Get(ctx)
 	if err != nil {
@@ -950,6 +966,13 @@ func (u *uploader) nextReader(ctx context.Context) (io.Reader, int, func(), erro
 		u.partPool.Put(part)
 	}
 	return bytes.NewReader(part[0:n]), n, cleanup, err
+}
+
+func (u *uploader) freshContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	if u.options.FailTimeout <= 0 {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(context.Background(), u.options.FailTimeout)
 }
 
 func readFillBuf(r io.Reader, b []byte) (offset int, err error) {
@@ -1007,7 +1030,9 @@ func (u *multiUploader) upload(ctx context.Context, firstBuf io.Reader, firstBuf
 		append(clientOptions, loc.WrapClient())...)
 	if err != nil {
 		cleanup()
-		u.progressEmitter.Failed(ctx, err)
+		freshCtx, cancel := u.freshContext(ctx)
+		defer cancel()
+		u.progressEmitter.Failed(freshCtx, err)
 		return nil, err
 	}
 	u.uploadID = resp.UploadId
@@ -1057,7 +1082,9 @@ func (u *multiUploader) upload(ctx context.Context, firstBuf io.Reader, firstBuf
 	completeOut := u.complete(ctx, clientOptions...)
 
 	if err := u.geterr(); err != nil {
-		u.progressEmitter.Failed(ctx, err)
+		freshCtx, cancel := u.freshContext(ctx)
+		defer cancel()
+		u.progressEmitter.Failed(freshCtx, err)
 		return nil, &multipartUploadError{
 			err:      err,
 			uploadID: *u.uploadID,
@@ -1152,7 +1179,9 @@ func (u *multiUploader) seterr(e error) {
 
 func (u *multiUploader) fail(ctx context.Context, clientOptions ...func(*s3.Options)) {
 	params := u.in.mapAbortMultipartUploadInput(u.uploadID)
-	_, err := u.options.S3.AbortMultipartUpload(ctx, params, clientOptions...)
+	freshCtx, cancel := u.freshContext(ctx)
+	defer cancel()
+	_, err := u.options.S3.AbortMultipartUpload(freshCtx, params, clientOptions...)
 	if err != nil {
 		u.seterr(fmt.Errorf("failed to abort multipart upload (%v), triggered after multipart upload failed: %v", err, u.geterr()))
 	}
@@ -1169,6 +1198,9 @@ func (u *multiUploader) complete(ctx context.Context, clientOptions ...func(*s3.
 	sort.Sort(u.parts)
 
 	params := u.in.mapCompleteMultipartUploadInput(u.uploadID, u.parts)
+	if params.MpuObjectSize == nil && u.objectSize > 0 {
+		params.MpuObjectSize = aws.Int64(u.objectSize)
+	}
 
 	resp, err := u.options.S3.CompleteMultipartUpload(ctx, params, clientOptions...)
 	if err != nil {

--- a/feature/s3/transfermanager/api_op_UploadObject.go
+++ b/feature/s3/transfermanager/api_op_UploadObject.go
@@ -1112,8 +1112,8 @@ func (u *multiUploader) shouldContinue(part int32, nextChunkLen int, err error) 
 	}
 
 	// This upload exceeded maximum number of supported parts, error now.
-	if part > defaultMaxUploadParts {
-		return false, fmt.Errorf("exceeded total allowed S3 limit MaxUploadParts (%d). Adjust PartSize to fit in this limit", defaultMaxUploadParts)
+	if int64(part) > u.options.MaxUploadParts {
+		return false, fmt.Errorf("exceeded total allowed MaxUploadParts (%d). Adjust PartSize to fit in this limit", u.options.MaxUploadParts)
 	}
 
 	return true, err

--- a/feature/s3/transfermanager/api_op_UploadObject.go
+++ b/feature/s3/transfermanager/api_op_UploadObject.go
@@ -213,6 +213,12 @@ type UploadObjectInput struct {
 	// [Checking object integrity]: https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html
 	ChecksumSHA512 *string
 
+	// Indicates the checksum type that you want Amazon S3 to use to calculate the
+	// object’s checksum value. For more information, see [Checking object integrity in the Amazon S3 User Guide].
+	//
+	// [Checking object integrity in the Amazon S3 User Guide]: https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html
+	ChecksumType types.ChecksumType
+
 	// Size of the body in bytes. This parameter is useful when the size of the body
 	// cannot be determined automatically. For more information, see [https://www.rfc-editor.org/rfc/rfc9110.html#name-content-length].
 	//
@@ -314,6 +320,11 @@ type UploadObjectInput struct {
 
 	// A map of metadata to store with the object in S3.
 	Metadata map[string]string
+
+	//  The expected total object size of the multipart upload request. If there’s a
+	// mismatch between the specified object size value and the actual object size
+	// value, it results in an HTTP 400 InvalidRequest error.
+	MpuObjectSize *int64
 
 	// Specifies whether a legal hold will be applied to this object. For more
 	// information about S3 Object Lock, see [Object Lock]in the Amazon S3 User Guide.
@@ -527,6 +538,7 @@ func (i UploadObjectInput) mapCreateMultipartUploadInput(checksumAlgorithm types
 		ACL:                       s3types.ObjectCannedACL(i.ACL),
 		BucketKeyEnabled:          i.BucketKeyEnabled,
 		CacheControl:              i.CacheControl,
+		ChecksumType:              s3types.ChecksumType(i.ChecksumType),
 		ContentDisposition:        i.ContentDisposition,
 		ContentEncoding:           i.ContentEncoding,
 		ContentLanguage:           i.ContentLanguage,
@@ -571,9 +583,11 @@ func (i UploadObjectInput) mapCompleteMultipartUploadInput(uploadID *string, com
 		ChecksumSHA1:         i.ChecksumSHA1,
 		ChecksumSHA256:       i.ChecksumSHA256,
 		ChecksumSHA512:       i.ChecksumSHA512,
+		ChecksumType:         s3types.ChecksumType(i.ChecksumType),
 		ExpectedBucketOwner:  i.ExpectedBucketOwner,
 		IfMatch:              i.IfMatch,
 		IfNoneMatch:          i.IfNoneMatch,
+		MpuObjectSize:        i.MpuObjectSize,
 		RequestPayer:         s3types.RequestPayer(i.RequestPayer),
 		SSECustomerAlgorithm: i.SSECustomerAlgorithm,
 		SSECustomerKey:       i.SSECustomerKey,

--- a/feature/s3/transfermanager/api_op_UploadObject_test.go
+++ b/feature/s3/transfermanager/api_op_UploadObject_test.go
@@ -345,6 +345,37 @@ func TestUploadOrderMultiWithMaxParts(t *testing.T) {
 	}
 }
 
+func TestUploadOrderMultiExceedMaxParts(t *testing.T) {
+	c, ops, args := s3testing.NewUploadLoggingClient(nil)
+	mgr := New(c, func(options *Options) {
+		options.MaxUploadParts = 2
+		options.Concurrency = 1
+	})
+
+	_, err := mgr.UploadObject(context.Background(), &UploadObjectInput{
+		Bucket: aws.String("Bucket"),
+		Key:    aws.String("Key"),
+		Body:   bytes.NewBuffer(buf20MB), // When size is unknown (streaming), error once the part count exceeds MaxUploadParts
+	})
+
+	if err == nil {
+		t.Errorf("expect error, got none")
+	} else if e, a := "exceeded total allowed MaxUploadParts", err.Error(); !strings.Contains(a, e) {
+		t.Errorf("expect %q to be contained in %q", e, a)
+	}
+
+	vals := []string{"CreateMultipartUpload", "UploadPart", "UploadPart", "AbortMultipartUpload"}
+	if !reflect.DeepEqual(vals, *ops) {
+		t.Errorf("expect %v, got %v", vals, *ops)
+	}
+
+	for i := 1; i <= 2; i++ {
+		if e, a := 1024*1024*8, getReaderLength((*args)[i].(*s3.UploadPartInput).Body); int64(e) != a {
+			t.Errorf("expect %d, got %d", e, a)
+		}
+	}
+}
+
 func TestUploadWithPartSizeIncreased(t *testing.T) {
 	c, ops, args := s3testing.NewUploadLoggingClient([]string{"CreateMultipartUpload", "CompleteMultipartUpload"})
 	mgr := New(c, func(o *Options) {
@@ -476,7 +507,7 @@ func TestUploadOrderZero(t *testing.T) {
 func TestUploadOrderMultiFailure(t *testing.T) {
 	c, invocations, _ := s3testing.NewUploadLoggingClient(nil)
 
-	c.UploadPartFn = func(u *s3testing.TransferManagerLoggingClient, params *s3.UploadPartInput) (*s3.UploadPartOutput, error) {
+	c.UploadPartFn = func(ctx context.Context, u *s3testing.TransferManagerLoggingClient, params *s3.UploadPartInput) (*s3.UploadPartOutput, error) {
 		if *params.PartNumber == 2 {
 			return nil, fmt.Errorf("an unexpected error")
 		}
@@ -998,7 +1029,7 @@ func TestUploadUnexpectedEOF(t *testing.T) {
 
 func TestSSE(t *testing.T) {
 	c, _, _ := s3testing.NewUploadLoggingClient(nil)
-	c.UploadPartFn = func(u *s3testing.TransferManagerLoggingClient, params *s3.UploadPartInput) (*s3.UploadPartOutput, error) {
+	c.UploadPartFn = func(ctx context.Context, u *s3testing.TransferManagerLoggingClient, params *s3.UploadPartInput) (*s3.UploadPartOutput, error) {
 		if params.SSECustomerAlgorithm == nil {
 			t.Fatal("SSECustomerAlgoritm should not be nil")
 		}
@@ -1047,6 +1078,42 @@ func TestUploadWithContextCanceled(t *testing.T) {
 
 	if e, a := "canceled", err.Error(); !strings.Contains(a, e) {
 		t.Errorf("expected error message to contain %q, but did not %q", e, a)
+	}
+}
+
+func TestUploadWithContextCanceledWhenUploadPart(t *testing.T) {
+	ctx := &awstesting.FakeContext{DoneCh: make(chan struct{})}
+	ctx.Error = fmt.Errorf("context canceled error which shouldn't be returned finally")
+	c, invocations, _ := s3testing.NewUploadLoggingClient(nil)
+	index := 0
+	c.UploadPartFn = func(context.Context, *s3testing.TransferManagerLoggingClient, *s3.UploadPartInput) (*s3.UploadPartOutput, error) {
+		if index > 0 {
+			close(ctx.DoneCh)
+			return &s3.UploadPartOutput{}, fmt.Errorf("upload part error due to context canceled")
+		}
+		index++
+		return &s3.UploadPartOutput{}, nil
+	}
+	u := New(c, func(o *Options) {
+		o.FailTimeout = 5 * time.Second
+	})
+
+	_, err := u.UploadObject(ctx, &UploadObjectInput{
+		Bucket: aws.String("Bucket"),
+		Key:    aws.String("Key"),
+		Body:   bytes.NewReader(make([]byte, 24*1024*1024)),
+	})
+	if err == nil {
+		t.Fatalf("expect error, got nil")
+	}
+	if e, a := "upload part error due to context canceled", err.Error(); !strings.Contains(a, e) {
+		t.Errorf("expected error message to contain %q, but did not %q", e, a)
+	} else if noe := "context canceled error which shouldn't be returned finally"; strings.Contains(a, noe) {
+		t.Errorf("expect %q to not be within %q", noe, a)
+	}
+
+	if diff := cmpDiff([]string{"CreateMultipartUpload", "UploadPart", "UploadPart", "AbortMultipartUpload"}, *invocations); len(diff) > 0 {
+		t.Error(diff)
 	}
 }
 

--- a/feature/s3/transfermanager/api_op_UploadObject_test.go
+++ b/feature/s3/transfermanager/api_op_UploadObject_test.go
@@ -18,10 +18,11 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	s3testing "github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager/internal/testing"
+	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager/types"
 	"github.com/aws/aws-sdk-go-v2/internal/awstesting"
 	"github.com/aws/aws-sdk-go-v2/internal/sdk"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 )
 
 // getReaderLength discards the bytes from reader and returns the length
@@ -38,6 +39,9 @@ func TestUploadOrderMulti(t *testing.T) {
 		Bucket:               aws.String("Bucket"),
 		Key:                  aws.String("Key - value"),
 		Body:                 bytes.NewReader(buf20MB),
+		ChecksumType:         types.ChecksumTypeFullObject,
+		ChecksumAlgorithm:    types.ChecksumAlgorithmCrc32c,
+		ChecksumCRC32C:       aws.String("CRC32CValue"),
 		ServerSideEncryption: "aws:kms",
 		SSEKMSKeyID:          aws.String("KmsId"),
 		ContentType:          aws.String("content/type"),
@@ -74,9 +78,16 @@ func TestUploadOrderMulti(t *testing.T) {
 	}
 
 	// CompleteMultipartUpload
-	v := aws.ToString((*args)[4].(*s3.CompleteMultipartUploadInput).UploadId)
-	if "UPLOAD-ID" != v {
+	completemu := (*args)[4].(*s3.CompleteMultipartUploadInput)
+
+	if v := aws.ToString(completemu.UploadId); "UPLOAD-ID" != v {
 		t.Errorf("Expected %q, but received %q", "UPLOAD-ID", v)
+	}
+	if e, a := "CRC32CValue", aws.ToString(completemu.ChecksumCRC32C); e != a {
+		t.Errorf("Expected %v, but received %v", e, a)
+	}
+	if e, a := s3types.ChecksumTypeFullObject, completemu.ChecksumType; e != a {
+		t.Errorf("Expected %v, but received %v", e, a)
 	}
 
 	parts := (*args)[4].(*s3.CompleteMultipartUploadInput).MultipartUpload.Parts
@@ -95,18 +106,26 @@ func TestUploadOrderMulti(t *testing.T) {
 	}
 
 	// Custom headers
-	cmu := (*args)[0].(*s3.CreateMultipartUploadInput)
+	createmu := (*args)[0].(*s3.CreateMultipartUploadInput)
 
-	if e, a := types.ServerSideEncryption("aws:kms"), cmu.ServerSideEncryption; e != a {
+	if e, a := s3types.ServerSideEncryption("aws:kms"), createmu.ServerSideEncryption; e != a {
 		t.Errorf("expect %q, got %q", e, a)
 	}
 
-	if e, a := "KmsId", aws.ToString(cmu.SSEKMSKeyId); e != a {
+	if e, a := "KmsId", aws.ToString(createmu.SSEKMSKeyId); e != a {
 		t.Errorf("expect %q, got %q", e, a)
 	}
 
-	if e, a := "content/type", aws.ToString(cmu.ContentType); e != a {
+	if e, a := "content/type", aws.ToString(createmu.ContentType); e != a {
 		t.Errorf("expect %q, got %q", e, a)
+	}
+
+	if e, a := s3types.ChecksumAlgorithmCrc32c, createmu.ChecksumAlgorithm; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+
+	if e, a := s3types.ChecksumTypeFullObject, createmu.ChecksumType; e != a {
+		t.Errorf("expect %v, got %v", e, a)
 	}
 }
 
@@ -165,7 +184,7 @@ func TestUploadOrderMultiTriggerredBySinglePartSize(t *testing.T) {
 	// Custom headers
 	cmu := (*args)[0].(*s3.CreateMultipartUploadInput)
 
-	if e, a := types.ServerSideEncryption("aws:kms"), cmu.ServerSideEncryption; e != a {
+	if e, a := s3types.ServerSideEncryption("aws:kms"), cmu.ServerSideEncryption; e != a {
 		t.Errorf("expect %q, got %q", e, a)
 	}
 
@@ -242,7 +261,7 @@ func TestUploadOrderMultiJustExceedSinglePart(t *testing.T) {
 	// Custom headers
 	cmu := (*args)[0].(*s3.CreateMultipartUploadInput)
 
-	if e, a := types.ServerSideEncryption("aws:kms"), cmu.ServerSideEncryption; e != a {
+	if e, a := s3types.ServerSideEncryption("aws:kms"), cmu.ServerSideEncryption; e != a {
 		t.Errorf("expect %q, got %q", e, a)
 	}
 
@@ -348,7 +367,7 @@ func TestUploadOrderSingle(t *testing.T) {
 
 	putObjectInput := (*params)[0].(*s3.PutObjectInput)
 
-	if e, a := types.ServerSideEncryption("aws:kms"), putObjectInput.ServerSideEncryption; e != a {
+	if e, a := s3types.ServerSideEncryption("aws:kms"), putObjectInput.ServerSideEncryption; e != a {
 		t.Errorf("expect %q, got %q", e, a)
 	}
 

--- a/feature/s3/transfermanager/api_op_UploadObject_test.go
+++ b/feature/s3/transfermanager/api_op_UploadObject_test.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/retry"
@@ -129,14 +130,14 @@ func TestUploadOrderMulti(t *testing.T) {
 	}
 }
 
-func TestUploadOrderMultiTriggerredBySinglePartSize(t *testing.T) {
+func TestSingleUploadLimitedByMPUThreshold(t *testing.T) {
 	c, invocations, args := s3testing.NewUploadLoggingClient(nil)
 	mgr := New(c)
 
 	resp, err := mgr.UploadObject(context.Background(), &UploadObjectInput{
 		Bucket:               aws.String("Bucket"),
 		Key:                  aws.String("Key - value"),
-		Body:                 bytes.NewReader(make([]byte, 8*1024*1024)),
+		Body:                 bytes.NewReader(make([]byte, 16*1024*1024-1)),
 		ServerSideEncryption: "aws:kms",
 		SSEKMSKeyID:          aws.String("KmsId"),
 		ContentType:          aws.String("content/type"),
@@ -146,65 +147,41 @@ func TestUploadOrderMultiTriggerredBySinglePartSize(t *testing.T) {
 		t.Errorf("Expected no error but received %v", err)
 	}
 
-	if diff := cmpDiff([]string{"CreateMultipartUpload", "UploadPart", "CompleteMultipartUpload"}, *invocations); len(diff) > 0 {
+	if diff := cmpDiff([]string{"PutObject"}, *invocations); len(diff) > 0 {
 		t.Error(diff)
-	}
-
-	if "UPLOAD-ID" != aws.ToString(resp.UploadID) {
-		t.Errorf("expect %q, got %q", "UPLOAD-ID", aws.ToString(resp.UploadID))
 	}
 
 	if "VERSION-ID" != aws.ToString(resp.VersionID) {
 		t.Errorf("expect %q, got %q", "VERSION-ID", aws.ToString(resp.VersionID))
 	}
 
-	// Validate input values
-	v := aws.ToString((*args)[1].(*s3.UploadPartInput).UploadId)
-	if "UPLOAD-ID" != v {
-		t.Errorf("Expected %q, but received %q", "UPLOAD-ID", v)
-	}
-	v = aws.ToString((*args)[2].(*s3.CompleteMultipartUploadInput).UploadId)
-	if "UPLOAD-ID" != v {
-		t.Errorf("Expected %q, but received %q", "UPLOAD-ID", v)
+	if len(aws.ToString(resp.UploadID)) > 0 {
+		t.Errorf("expect empty string, got %q", aws.ToString(resp.UploadID))
 	}
 
-	parts := (*args)[2].(*s3.CompleteMultipartUploadInput).MultipartUpload.Parts
+	putObjectInput := (*args)[0].(*s3.PutObjectInput)
 
-	num := parts[0].PartNumber
-	etag := aws.ToString(parts[0].ETag)
-
-	if aws.ToInt32(num) != 1 {
-		t.Errorf("expect part number to be 1, got %d", num)
-	}
-
-	if matched, err := regexp.MatchString(`^ETAG\d+$`, etag); !matched || err != nil {
-		t.Errorf("Failed regexp expression `^ETAG\\d+$`, got %s", etag)
-	}
-
-	// Custom headers
-	cmu := (*args)[0].(*s3.CreateMultipartUploadInput)
-
-	if e, a := s3types.ServerSideEncryption("aws:kms"), cmu.ServerSideEncryption; e != a {
+	if e, a := s3types.ServerSideEncryption("aws:kms"), putObjectInput.ServerSideEncryption; e != a {
 		t.Errorf("expect %q, got %q", e, a)
 	}
 
-	if e, a := "KmsId", aws.ToString(cmu.SSEKMSKeyId); e != a {
+	if e, a := "KmsId", aws.ToString(putObjectInput.SSEKMSKeyId); e != a {
 		t.Errorf("expect %q, got %q", e, a)
 	}
 
-	if e, a := "content/type", aws.ToString(cmu.ContentType); e != a {
-		t.Errorf("expect %q, got %q", e, a)
+	if e, a := "content/type", aws.ToString(putObjectInput.ContentType); e != a {
+		t.Errorf("Expected %q, but received %q", e, a)
 	}
 }
 
-func TestUploadOrderMultiJustExceedSinglePart(t *testing.T) {
+func TestUploadOrderMultiJustMeetThreshold(t *testing.T) {
 	c, invocations, args := s3testing.NewUploadLoggingClient(nil)
 	mgr := New(c)
 
 	resp, err := mgr.UploadObject(context.Background(), &UploadObjectInput{
 		Bucket:               aws.String("Bucket"),
 		Key:                  aws.String("Key - value"),
-		Body:                 bytes.NewReader(make([]byte, 8*1024*1024+1)),
+		Body:                 bytes.NewReader(make([]byte, 16*1024*1024)),
 		ServerSideEncryption: "aws:kms",
 		SSEKMSKeyID:          aws.String("KmsId"),
 		ContentType:          aws.String("content/type"),
@@ -298,10 +275,73 @@ func TestUploadOrderMultiDifferentPartSize(t *testing.T) {
 
 	// Part lengths
 	if len := getReaderLength((*args)[1].(*s3.UploadPartInput).Body); 1024*1024*11 != len {
-		t.Errorf("expect %d, got %d", 1024*1024*7, len)
+		t.Errorf("expect %d, got %d", 1024*1024*11, len)
 	}
 	if len := getReaderLength((*args)[2].(*s3.UploadPartInput).Body); 1024*1024*9 != len {
-		t.Errorf("expect %d, got %d", 1024*1024*5, len)
+		t.Errorf("expect %d, got %d", 1024*1024*9, len)
+	}
+}
+
+func TestUploadOrderMultiWithPartSizeEqualToThreshold(t *testing.T) {
+	c, ops, args := s3testing.NewUploadLoggingClient(nil)
+	mgr := New(c, func(options *Options) {
+		options.PartSizeBytes = 1024 * 1024 * 16
+		options.Concurrency = 1
+	})
+
+	_, err := mgr.UploadObject(context.Background(), &UploadObjectInput{
+		Bucket: aws.String("Bucket"),
+		Key:    aws.String("Key"),
+		Body:   bytes.NewReader(buf20MB),
+	})
+
+	if err != nil {
+		t.Errorf("expect no error, got %v", err)
+	}
+
+	vals := []string{"CreateMultipartUpload", "UploadPart", "UploadPart", "CompleteMultipartUpload"}
+	if !reflect.DeepEqual(vals, *ops) {
+		t.Errorf("expect %v, got %v", vals, *ops)
+	}
+
+	// Part lengths
+	if e, a := 1024*1024*16, getReaderLength((*args)[1].(*s3.UploadPartInput).Body); int64(e) != a {
+		t.Errorf("expect %d, got %d", e, a)
+	}
+	if e, a := 1024*1024*4, getReaderLength((*args)[2].(*s3.UploadPartInput).Body); int64(e) != a {
+		t.Errorf("expect %d, got %d", e, a)
+	}
+}
+
+func TestUploadOrderMultiWithMaxParts(t *testing.T) {
+	c, ops, args := s3testing.NewUploadLoggingClient(nil)
+	mgr := New(c, func(options *Options) {
+		options.MaxUploadParts = 2
+		options.Concurrency = 1
+	})
+
+	_, err := mgr.UploadObject(context.Background(), &UploadObjectInput{
+		Bucket: aws.String("Bucket"),
+		Key:    aws.String("Key"),
+		Body:   bytes.NewReader(buf40MB),
+	})
+
+	if err != nil {
+		t.Errorf("expect no error, got %v", err)
+	}
+
+	vals := []string{"CreateMultipartUpload", "UploadPart", "UploadPart", "CompleteMultipartUpload"}
+	if !reflect.DeepEqual(vals, *ops) {
+		t.Errorf("expect %v, got %v", vals, *ops)
+	}
+
+	// max 2 parts means the part size will be recalculated to 40MB/2+1=20MB + 1
+	// Part lengths
+	if e, a := 1024*1024*20+1, getReaderLength((*args)[1].(*s3.UploadPartInput).Body); int64(e) != a {
+		t.Errorf("expect %d, got %d", e, a)
+	}
+	if e, a := 1024*1024*20-1, getReaderLength((*args)[2].(*s3.UploadPartInput).Body); int64(e) != a {
+		t.Errorf("expect %d, got %d", e, a)
 	}
 }
 
@@ -464,7 +504,7 @@ func TestUploadOrderMultiFailure(t *testing.T) {
 func TestUploadOrderMultiFailureOnComplete(t *testing.T) {
 	c, invocations, _ := s3testing.NewUploadLoggingClient(nil)
 
-	c.CompleteMultipartUploadFn = func(*s3testing.TransferManagerLoggingClient, *s3.CompleteMultipartUploadInput) (*s3.CompleteMultipartUploadOutput, error) {
+	c.CompleteMultipartUploadFn = func(context.Context, *s3testing.TransferManagerLoggingClient, *s3.CompleteMultipartUploadInput) (*s3.CompleteMultipartUploadOutput, error) {
 		return nil, fmt.Errorf("complete multipart error")
 	}
 
@@ -479,6 +519,8 @@ func TestUploadOrderMultiFailureOnComplete(t *testing.T) {
 
 	if err == nil {
 		t.Error("expect error, got nil")
+	} else if e, a := "complete multipart error", err.Error(); !strings.Contains(a, e) {
+		t.Errorf("Expected %v to be contained in %q", e, a)
 	}
 
 	if diff := cmpDiff([]string{"CreateMultipartUpload", "UploadPart", "UploadPart", "UploadPart",
@@ -498,7 +540,7 @@ func TestUploadOrderMultiFailureOnCreate(t *testing.T) {
 	_, err := mgr.UploadObject(context.Background(), &UploadObjectInput{
 		Bucket: aws.String("Bucket"),
 		Key:    aws.String("Key"),
-		Body:   bytes.NewReader(make([]byte, 1024*1024*12)),
+		Body:   bytes.NewReader(make([]byte, 1024*1024*16)),
 	})
 
 	if err == nil {
@@ -552,7 +594,7 @@ func TestUploadOrderReadFail2(t *testing.T) {
 	_, err := mgr.UploadObject(context.Background(), &UploadObjectInput{
 		Bucket: aws.String("Bucket"),
 		Key:    aws.String("Key"),
-		Body:   &failreader{failBytes: 8 * 1024 * 1024},
+		Body:   &failreader{failBytes: 16*1024*1024 + 1},
 	})
 	if err == nil {
 		t.Fatalf("expect error to not be nil")
@@ -619,13 +661,15 @@ func TestUploadOrderMultiBufferedReader(t *testing.T) {
 	}
 }
 
-func TestUploadOrderMultiBufferedReaderWithSinglePartSize(t *testing.T) {
+func TestUploadOrderMultiBufferedReaderWithSinglePartSizeThreshold(t *testing.T) {
 	c, invocations, params := s3testing.NewUploadLoggingClient(nil)
-	mgr := New(c)
+	mgr := New(c, func(o *Options) {
+		o.MultipartUploadThreshold = defaultPartSizeBytes
+	})
 	_, err := mgr.UploadObject(context.Background(), &UploadObjectInput{
 		Bucket: aws.String("Bucket"),
 		Key:    aws.String("Key"),
-		Body:   &sizedReader{size: 1024 * 1024 * 8},
+		Body:   &sizedReader{size: defaultPartSizeBytes},
 	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
@@ -644,31 +688,31 @@ func TestUploadOrderMultiBufferedReaderWithSinglePartSize(t *testing.T) {
 	}
 }
 
-func TestUploadOrderMultiBufferedReaderJustExceedSinglePart(t *testing.T) {
+func TestUploadOrderMultiBufferedReaderJustExceedMPUThreshold(t *testing.T) {
 	c, invocations, params := s3testing.NewUploadLoggingClient(nil)
 	mgr := New(c)
 	_, err := mgr.UploadObject(context.Background(), &UploadObjectInput{
 		Bucket: aws.String("Bucket"),
 		Key:    aws.String("Key"),
-		Body:   &sizedReader{size: defaultPartSizeBytes + 1},
+		Body:   &sizedReader{size: defaultMultipartUploadThreshold + 1},
 	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}
 
-	if diff := cmpDiff([]string{"CreateMultipartUpload", "UploadPart", "UploadPart",
+	if diff := cmpDiff([]string{"CreateMultipartUpload", "UploadPart", "UploadPart", "UploadPart",
 		"CompleteMultipartUpload"}, *invocations); len(diff) > 0 {
 		t.Error(diff)
 	}
 
 	// Part lengths
 	var parts []int64
-	for i := 1; i < 3; i++ {
+	for i := 1; i < 4; i++ {
 		parts = append(parts, getReaderLength((*params)[i].(*s3.UploadPartInput).Body))
 	}
 	slices.Sort(parts)
 
-	if diff := cmpDiff([]int64{1, 1024 * 1024 * 8}, parts); len(diff) > 0 {
+	if diff := cmpDiff([]int64{1, 1024 * 1024 * 8, 1024 * 1024 * 8}, parts); len(diff) > 0 {
 		t.Error(diff)
 	}
 }
@@ -868,6 +912,49 @@ func TestProgressListener_MultiUpload(t *testing.T) {
 		eightMB*5)
 }
 
+func TestProgressListener_MultiUploadFailAtComplete(t *testing.T) {
+	ctx := &awstesting.FakeContext{DoneCh: make(chan struct{})}
+	ctx.Error = fmt.Errorf("context canceled error which shouldn't be returned finally")
+	c, _, _ := s3testing.NewUploadLoggingClient(nil)
+	c.CompleteMultipartUploadFn = func(context.Context, *s3testing.TransferManagerLoggingClient, *s3.CompleteMultipartUploadInput) (*s3.CompleteMultipartUploadOutput, error) {
+		close(ctx.DoneCh)
+		return &s3.CompleteMultipartUploadOutput{}, fmt.Errorf("complete mpu error due to context canceled")
+	}
+
+	listener := &mockListener{}
+
+	mgr := New(c, func(options *Options) {
+		options.ObjectProgressListeners.Register(listener)
+		options.Concurrency = 1
+		options.FailTimeout = 5 * time.Second
+	})
+
+	in := &UploadObjectInput{
+		Bucket: aws.String("Bucket"),
+		Key:    aws.String("Key"),
+		Body:   bytes.NewReader(buf40MB),
+	}
+	_, err := mgr.UploadObject(context.Background(), in)
+	if err == nil {
+		t.Fatal("expect error but received none")
+	}
+
+	objectSize := int64(len(buf40MB))
+	listener.expectStartTotalBytes(t, objectSize)
+	listener.expectFailed(t, in, err.(*multipartUploadError).err)
+
+	// 40MB / 8 (default part size) = 5 expected events
+	// we keep the input size a multiple of the part size so the intermediate
+	// byte counts are predictable
+	const eightMB = 1024 * 1024 * 8
+	listener.expectByteTransfers(t,
+		eightMB,
+		eightMB*2,
+		eightMB*3,
+		eightMB*4,
+		eightMB*5)
+}
+
 type testIncompleteReader struct {
 	Size int64
 	read int64
@@ -885,13 +972,12 @@ func TestUploadUnexpectedEOF(t *testing.T) {
 	c, invocations, _ := s3testing.NewUploadLoggingClient(nil)
 	mgr := New(c, func(o *Options) {
 		o.Concurrency = 1
-		o.PartSizeBytes = defaultPartSizeBytes
 	})
 	_, err := mgr.UploadObject(context.Background(), &UploadObjectInput{
 		Bucket: aws.String("Bucket"),
 		Key:    aws.String("Key"),
 		Body: &testIncompleteReader{
-			Size: defaultPartSizeBytes + 1,
+			Size: defaultMultipartUploadThreshold + 1,
 		},
 	})
 	if err == nil {
@@ -961,6 +1047,37 @@ func TestUploadWithContextCanceled(t *testing.T) {
 
 	if e, a := "canceled", err.Error(); !strings.Contains(a, e) {
 		t.Errorf("expected error message to contain %q, but did not %q", e, a)
+	}
+}
+
+func TestUploadWithContextCanceledWhenComplete(t *testing.T) {
+	ctx := &awstesting.FakeContext{DoneCh: make(chan struct{})}
+	ctx.Error = fmt.Errorf("context canceled error which shouldn't be returned finally")
+	c, invocations, _ := s3testing.NewUploadLoggingClient(nil)
+	c.CompleteMultipartUploadFn = func(context.Context, *s3testing.TransferManagerLoggingClient, *s3.CompleteMultipartUploadInput) (*s3.CompleteMultipartUploadOutput, error) {
+		close(ctx.DoneCh)
+		return &s3.CompleteMultipartUploadOutput{}, fmt.Errorf("complete mpu error due to context canceled")
+	}
+	u := New(c, func(o *Options) {
+		o.FailTimeout = 5 * time.Second
+	})
+
+	_, err := u.UploadObject(ctx, &UploadObjectInput{
+		Bucket: aws.String("Bucket"),
+		Key:    aws.String("Key"),
+		Body:   bytes.NewReader(make([]byte, 16*1024*1024)),
+	})
+	if err == nil {
+		t.Fatalf("expect error, got nil")
+	}
+	if e, a := "complete mpu error due to context canceled", err.Error(); !strings.Contains(a, e) {
+		t.Errorf("expected error message to contain %q, but did not %q", e, a)
+	} else if noe := "context canceled error which shouldn't be returned finally"; strings.Contains(a, noe) {
+		t.Errorf("expect %q to not be within %q", noe, a)
+	}
+
+	if diff := cmpDiff([]string{"CreateMultipartUpload", "UploadPart", "UploadPart", "CompleteMultipartUpload", "AbortMultipartUpload"}, *invocations); len(diff) > 0 {
+		t.Error(diff)
 	}
 }
 

--- a/feature/s3/transfermanager/downloadobject_test.go
+++ b/feature/s3/transfermanager/downloadobject_test.go
@@ -25,6 +25,7 @@ func TestDownloadObject(t *testing.T) {
 		data                 []byte
 		errReaders           []s3testing.TestErrReader
 		getObjectFn          func(*s3testing.TransferManagerLoggingClient, *s3.GetObjectInput) (*s3.GetObjectOutput, error)
+		rng                  string
 		optFn                func(*Options)
 		expectInvocations    int
 		expectRanges         []string
@@ -87,6 +88,50 @@ func TestDownloadObject(t *testing.T) {
 				l.expectByteTransfers(t,
 					10*megabyte, 20*megabyte)
 			},
+		},
+		"single range download with specified range input": {
+			data:        buf20MB,
+			getObjectFn: s3testing.RangeGetObjectFn,
+			optFn: func(o *Options) {
+				o.GetObjectType = types.GetObjectRanges
+			},
+			rng:               "bytes=2-8388609",
+			expectInvocations: 1,
+			expectRanges:      []string{"bytes=2-8388609"},
+			expectETags:       []string{""},
+			listenerValidationFn: func(t *testing.T, l *mockListener, in, out any, err error) {
+				l.expectComplete(t, in, out)
+				l.expectStartTotalBytes(t, 8388608)
+				l.expectByteTransfers(t,
+					8*megabyte)
+			},
+		},
+		"multiple range download with specified range input": {
+			data:        buf20MB,
+			getObjectFn: s3testing.RangeGetObjectFn,
+			optFn: func(o *Options) {
+				o.GetObjectType = types.GetObjectRanges
+				o.Concurrency = 1
+			},
+			rng:               "bytes=2-16777218",
+			expectInvocations: 3,
+			expectRanges:      []string{"bytes=2-8388609", "bytes=8388610-16777217", "bytes=16777218-16777218"},
+			expectETags:       []string{"", etag, etag},
+			listenerValidationFn: func(t *testing.T, l *mockListener, in, out any, err error) {
+				l.expectComplete(t, in, out)
+				l.expectStartTotalBytes(t, 16777217)
+				l.expectByteTransfers(t,
+					8*megabyte, 16*megabyte, 16*megabyte+1)
+			},
+		},
+		"range download with invalid range input": {
+			data:        buf20MB,
+			getObjectFn: s3testing.RangeGetObjectFn,
+			optFn: func(o *Options) {
+				o.GetObjectType = types.GetObjectRanges
+			},
+			rng:       "bytes=-2-8388609",
+			expectErr: "invalid range format",
 		},
 		"range download with s3 error": {
 			data:        buf20MB,
@@ -412,6 +457,7 @@ func TestDownloadObject(t *testing.T) {
 				Key:       aws.String("key"),
 				WriterAt:  w,
 				VersionID: nzstring(c.versionID),
+				Range:     aws.String(c.rng),
 			}
 
 			listener := &mockListener{}

--- a/feature/s3/transfermanager/getobject_test.go
+++ b/feature/s3/transfermanager/getobject_test.go
@@ -29,6 +29,7 @@ func TestGetObject(t *testing.T) {
 		errReaders        []s3testing.TestErrReader
 		getObjectFn       func(*s3testing.TransferManagerLoggingClient, *s3.GetObjectInput) (*s3.GetObjectOutput, error)
 		optFn             func(*Options)
+		rng               string
 		versionID         string
 		checksumType      s3types.ChecksumType
 		expectInvocations int
@@ -51,6 +52,38 @@ func TestGetObject(t *testing.T) {
 			expectInvocations: 3,
 			expectRanges:      []string{"bytes=0-8388607", "bytes=8388608-16777215", "bytes=16777216-20971519"},
 			expectETags:       []string{etag, etag, etag},
+		},
+		"range download a limited range in single chunk": {
+			data:        buf20MB,
+			getObjectFn: s3testing.RangeGetObjectFn,
+			optFn: func(o *Options) {
+				o.GetObjectType = types.GetObjectRanges
+			},
+			rng:               "bytes=2-8388609",
+			expectInvocations: 1,
+			expectRanges:      []string{"bytes=2-8388609"},
+			expectETags:       []string{etag},
+		},
+		"range download a limited range sequentially in multiple chunks": {
+			data:        buf20MB,
+			getObjectFn: s3testing.RangeGetObjectFn,
+			optFn: func(o *Options) {
+				o.GetObjectType = types.GetObjectRanges
+				o.Concurrency = 1
+			},
+			rng:               "bytes=2-16777218",
+			expectInvocations: 3,
+			expectRanges:      []string{"bytes=2-8388609", "bytes=8388610-16777217", "bytes=16777218-16777218"},
+			expectETags:       []string{etag, etag, etag},
+		},
+		"range download a limited range with invalid range input": {
+			data:        buf20MB,
+			getObjectFn: s3testing.RangeGetObjectFn,
+			optFn: func(o *Options) {
+				o.GetObjectType = types.GetObjectRanges
+			},
+			rng:          "bytes=2--8388609",
+			expectGetErr: "invalid range format",
 		},
 		"range download zero": {
 			data:        []byte{},
@@ -288,6 +321,7 @@ func TestGetObject(t *testing.T) {
 			input := &GetObjectInput{
 				Bucket: aws.String("bucket"),
 				Key:    aws.String("key"),
+				Range:  aws.String(c.rng),
 			}
 			input.VersionID = nzstring(c.versionID)
 

--- a/feature/s3/transfermanager/internal/testing/client.go
+++ b/feature/s3/transfermanager/internal/testing/client.go
@@ -59,7 +59,7 @@ type TransferManagerLoggingClient struct {
 	PutObjectFn               func(*TransferManagerLoggingClient, *s3.PutObjectInput) (*s3.PutObjectOutput, error)
 	UploadPartFn              func(*TransferManagerLoggingClient, *s3.UploadPartInput) (*s3.UploadPartOutput, error)
 	CreateMultipartUploadFn   func(*TransferManagerLoggingClient, *s3.CreateMultipartUploadInput) (*s3.CreateMultipartUploadOutput, error)
-	CompleteMultipartUploadFn func(*TransferManagerLoggingClient, *s3.CompleteMultipartUploadInput) (*s3.CompleteMultipartUploadOutput, error)
+	CompleteMultipartUploadFn func(context.Context, *TransferManagerLoggingClient, *s3.CompleteMultipartUploadInput) (*s3.CompleteMultipartUploadOutput, error)
 	AbortMultipartUploadFn    func(*TransferManagerLoggingClient, *s3.AbortMultipartUploadInput) (*s3.AbortMultipartUploadOutput, error)
 	GetObjectFn               func(*TransferManagerLoggingClient, *s3.GetObjectInput) (*s3.GetObjectOutput, error)
 }
@@ -188,7 +188,7 @@ func (c *TransferManagerLoggingClient) CompleteMultipartUpload(ctx context.Conte
 	}
 
 	if c.CompleteMultipartUploadFn != nil {
-		return c.CompleteMultipartUploadFn(c, params)
+		return c.CompleteMultipartUploadFn(ctx, c, params)
 	}
 
 	return &s3.CompleteMultipartUploadOutput{
@@ -201,6 +201,10 @@ func (c *TransferManagerLoggingClient) CompleteMultipartUpload(ctx context.Conte
 func (c *TransferManagerLoggingClient) AbortMultipartUpload(ctx context.Context, params *s3.AbortMultipartUploadInput, optFns ...func(*s3.Options)) (*s3.AbortMultipartUploadOutput, error) {
 	c.m.Lock()
 	defer c.m.Unlock()
+
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
 
 	c.traceOperation("AbortMultipartUpload", params)
 	if err := c.simulateHTTPClientOption(optFns...); err != nil {

--- a/feature/s3/transfermanager/internal/testing/client.go
+++ b/feature/s3/transfermanager/internal/testing/client.go
@@ -57,7 +57,7 @@ type TransferManagerLoggingClient struct {
 	m sync.Mutex
 
 	PutObjectFn               func(*TransferManagerLoggingClient, *s3.PutObjectInput) (*s3.PutObjectOutput, error)
-	UploadPartFn              func(*TransferManagerLoggingClient, *s3.UploadPartInput) (*s3.UploadPartOutput, error)
+	UploadPartFn              func(context.Context, *TransferManagerLoggingClient, *s3.UploadPartInput) (*s3.UploadPartOutput, error)
 	CreateMultipartUploadFn   func(*TransferManagerLoggingClient, *s3.CreateMultipartUploadInput) (*s3.CreateMultipartUploadOutput, error)
 	CompleteMultipartUploadFn func(context.Context, *TransferManagerLoggingClient, *s3.CompleteMultipartUploadInput) (*s3.CompleteMultipartUploadOutput, error)
 	AbortMultipartUploadFn    func(*TransferManagerLoggingClient, *s3.AbortMultipartUploadInput) (*s3.AbortMultipartUploadOutput, error)
@@ -148,7 +148,7 @@ func (c *TransferManagerLoggingClient) UploadPart(ctx context.Context, params *s
 	}
 
 	if c.UploadPartFn != nil {
-		return c.UploadPartFn(c, params)
+		return c.UploadPartFn(ctx, c, params)
 	}
 
 	return &s3.UploadPartOutput{

--- a/feature/s3/transfermanager/options.go
+++ b/feature/s3/transfermanager/options.go
@@ -26,6 +26,7 @@ type Options struct {
 	FailTimeout time.Duration
 
 	// The max parts count for a multi part upload, which could not exceed defaultMaxUploadParts defined by s3 side
+	// https://docs.aws.amazon.com/AmazonS3/latest/userguide/qfacts.html
 	MaxUploadParts int64
 
 	// Option to disable checksum validation for download

--- a/feature/s3/transfermanager/options.go
+++ b/feature/s3/transfermanager/options.go
@@ -1,6 +1,8 @@
 package transfermanager
 
 import (
+	"time"
+
 	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager/types"
 )
 
@@ -16,6 +18,15 @@ type Options struct {
 
 	// The threshold bytes to decide when the file should be multi-uploaded
 	MultipartUploadThreshold int64
+
+	// FailTimeout is the timeout for transfer failure handling when a transfer fails.
+	// A fresh context with this timeout is used so failure followup (AbortMPU for upload or possible progress listener work)
+	// succeed even when the original context is canceled.
+	// Defaults to 0 (uses the original context) for fail case not caused by ctx cancellation.
+	FailTimeout time.Duration
+
+	// The max parts count for a multi part upload, which could not exceed defaultMaxUploadParts defined by s3 side
+	MaxUploadParts int64
 
 	// Option to disable checksum validation for download
 	DisableChecksumValidation bool
@@ -95,6 +106,12 @@ func resolvePartBodyMaxRetries(o *Options) {
 func resolveGetBufferSize(o *Options) {
 	if o.GetObjectBufferSize == 0 {
 		o.GetObjectBufferSize = defaultGetBufferSize
+	}
+}
+
+func resolveMaxUploadParts(o *Options) {
+	if o.MaxUploadParts == 0 {
+		o.MaxUploadParts = defaultMaxUploadParts
 	}
 }
 

--- a/feature/s3/transfermanager/options.go
+++ b/feature/s3/transfermanager/options.go
@@ -25,7 +25,7 @@ type Options struct {
 	// Defaults to 0 (uses the original context) for fail case not caused by ctx cancellation.
 	FailTimeout time.Duration
 
-	// The max parts count for a multi part upload, which could not exceed defaultMaxUploadParts defined by s3 side
+	// The max parts count for a multi part upload, which must not exceed "Maximum number of parts per upload" defined by S3
 	// https://docs.aws.amazon.com/AmazonS3/latest/userguide/qfacts.html
 	MaxUploadParts int64
 

--- a/feature/s3/transfermanager/progress_listener_test.go
+++ b/feature/s3/transfermanager/progress_listener_test.go
@@ -75,6 +75,11 @@ func (m *mockListener) OnObjectTransferFailed(ctx context.Context, event *Object
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	if ctx.Err() != nil {
+		return
+	}
+
+	// only listen failure when the input ctx still works
 	m.failed = append(m.failed, event)
 }
 
@@ -211,6 +216,11 @@ func (m *mockDirectoryListener) OnObjectsTransferFailed(ctx context.Context, eve
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	if ctx.Err() != nil {
+		return
+	}
+
+	// only listen failure when the input ctx still works
 	m.failed = append(m.failed, event)
 }
 

--- a/feature/s3/transfermanager/setup_integ_test.go
+++ b/feature/s3/transfermanager/setup_integ_test.go
@@ -214,13 +214,16 @@ func setupBuckets(ctx context.Context) (func(), error) {
 }
 
 type putObjectTestData struct {
-	Body        io.Reader
-	ExpectBody  []byte
-	ExpectError string
+	Body              io.Reader
+	ChecksumAlgorithm types.ChecksumAlgorithm
+	ChecksumType      types.ChecksumType
+	ExpectBody        []byte
+	ExpectError       string
 }
 
 type downloadObjectTestData struct {
 	Body        io.Reader
+	Range       string
 	ExpectBody  []byte
 	ExpectError string
 	OptFns      []func(*Options)
@@ -228,6 +231,7 @@ type downloadObjectTestData struct {
 
 type getObjectTestData struct {
 	Body            io.Reader
+	Range           string
 	ExpectBody      []byte
 	ExpectGetError  string
 	ExpectReadError string
@@ -249,9 +253,11 @@ func testPutObject(t *testing.T, bucket string, testData putObjectTestData, opts
 
 	_, err := s3TransferManagerClient.UploadObject(context.Background(),
 		&UploadObjectInput{
-			Bucket: aws.String(bucket),
-			Key:    aws.String(key),
-			Body:   testData.Body,
+			Bucket:            aws.String(bucket),
+			Key:               aws.String(key),
+			Body:              testData.Body,
+			ChecksumAlgorithm: testData.ChecksumAlgorithm,
+			ChecksumType:      testData.ChecksumType,
 		}, opts...)
 	if err != nil {
 		if len(testData.ExpectError) == 0 {
@@ -283,6 +289,10 @@ func testPutObject(t *testing.T, bucket string, testData putObjectTestData, opts
 	if e, a := testData.ExpectBody, b; !bytes.EqualFold(e, a) {
 		t.Errorf("expect %s, got %s", e, a)
 	}
+
+	if e, a := string(testData.ChecksumType), string(resp.ChecksumType); e != "" && e != a {
+		t.Errorf("expect %s, got %s", e, a)
+	}
 }
 
 func testGetObject(t *testing.T, bucket string, testData getObjectTestData) {
@@ -302,6 +312,7 @@ func testGetObject(t *testing.T, bucket string, testData getObjectTestData) {
 		&GetObjectInput{
 			Bucket: aws.String(bucket),
 			Key:    aws.String(key),
+			Range:  aws.String(testData.Range),
 		}, testData.OptFns...)
 
 	if err != nil {
@@ -360,6 +371,7 @@ func testDownloadObject(t *testing.T, bucket string, testData downloadObjectTest
 			Bucket:   aws.String(bucket),
 			Key:      aws.String(key),
 			WriterAt: w,
+			Range:    aws.String(testData.Range),
 		}, testData.OptFns...)
 	if err != nil {
 		if len(testData.ExpectError) == 0 {


### PR DESCRIPTION
Updated feature/s3/transfermanager to add following features missed from old tm v1 or complained by users:

- Add back range download for single object #3322 
- Support checksum type config #3326 
- Fix error when running following listener/cleanup of failed transferl, which is caused by context cancellation #3341 
- Honor mpu threshold option which was ignored before #3408 
- Add back max upload parts option for single object #3407  