### PR TITLE
credentials/logincreds: create new cache files with 0600

### DIFF
--- a/.changelog/a6d8b214008d4e7b991be6379ca77900.json
+++ b/.changelog/a6d8b214008d4e7b991be6379ca77900.json
@@ -1,0 +1,9 @@
+{
+    "id": "a6d8b214-008d-4e7b-991b-e6379ca77900",
+    "type": "bugfix",
+    "description": "Adds support for AWS_RESTRICT_FILE_PERMISSIONS for env and in-code config.",
+    "modules": [
+        ".",
+        "config"
+    ]
+}

--- a/.changelog/bf82a36937074b4094ef1dc3fbe613a7.json
+++ b/.changelog/bf82a36937074b4094ef1dc3fbe613a7.json
@@ -1,0 +1,8 @@
+{
+    "id": "bf82a369-3707-4b40-94ef-1dc3fbe613a7",
+    "type": "bugfix",
+    "description": "Create new login cache files with 0600 on Unix platforms.",
+    "modules": [
+        "credentials"
+    ]
+}

--- a/aws/config.go
+++ b/aws/config.go
@@ -204,6 +204,10 @@ type Config struct {
 	// when constructing clients for specific services. Each callback function receives the service ID
 	// and the service's Options struct, allowing for dynamic configuration based on the service.
 	ServiceOptions []func(string, any)
+
+	// Controls whether the SDK restricts file permissions on credential
+	// cache files it creates.
+	RestrictFilePermissions RestrictFilePermissions
 }
 
 // NewConfig returns a new Config pointer that can be chained with builder

--- a/aws/restrict_file_permissions.go
+++ b/aws/restrict_file_permissions.go
@@ -5,15 +5,17 @@ package aws
 type RestrictFilePermissions string
 
 const (
-	// Unset.
+	// RestrictFilePermissionsUnset indicates the setting has not been
+	// configured.
 	RestrictFilePermissionsUnset RestrictFilePermissions = ""
 
-	// Sets file permissions to owner read/write only (0600) and directory
-	// permissions to owner only (0700) when creating new cache files and
-	// directories on Unix. This is the default behavior.
-	RestrictFilePermissionsUserReadWrite = "user_read_write"
+	// RestrictFilePermissionsUserReadWrite sets file permissions to owner
+	// read/write only (0600) and directory permissions to owner only (0700)
+	// when creating new cache files and directories on Unix. This is the
+	// default behavior.
+	RestrictFilePermissionsUserReadWrite RestrictFilePermissions = "user_read_write"
 
-	// Does not set any file or directory permissions, relying on the system's
-	// default umask.
-	RestrictFilePermissionsUnrestricted = "unrestricted"
+	// RestrictFilePermissionsUnrestricted does not set any file or directory
+	// permissions, relying on the system's default umask.
+	RestrictFilePermissionsUnrestricted RestrictFilePermissions = "unrestricted"
 )

--- a/aws/restrict_file_permissions.go
+++ b/aws/restrict_file_permissions.go
@@ -1,0 +1,19 @@
+package aws
+
+// RestrictFilePermissions controls whether the SDK restricts file permissions
+// on credential cache files it creates.
+type RestrictFilePermissions string
+
+const (
+	// Unset.
+	RestrictFilePermissionsUnset RestrictFilePermissions = ""
+
+	// Sets file permissions to owner read/write only (0600) and directory
+	// permissions to owner only (0700) when creating new cache files and
+	// directories on Unix. This is the default behavior.
+	RestrictFilePermissionsUserReadWrite = "user_read_write"
+
+	// Does not set any file or directory permissions, relying on the system's
+	// default umask.
+	RestrictFilePermissionsUnrestricted = "unrestricted"
+)

--- a/config/config.go
+++ b/config/config.go
@@ -96,6 +96,8 @@ var defaultAWSConfigResolvers = []awsConfigResolver{
 
 	// Sets the ServiceOptions if present in LoadOptions
 	resolveServiceOptions,
+
+	resolveRestrictFilePermissions,
 }
 
 // A Config represents a generic configuration value or set of values. This type

--- a/config/env_config.go
+++ b/config/env_config.go
@@ -87,6 +87,8 @@ const (
 	awsResponseChecksumValidation = "AWS_RESPONSE_CHECKSUM_VALIDATION"
 
 	awsAuthSchemePreferenceEnv = "AWS_AUTH_SCHEME_PREFERENCE"
+
+	awsRestrictFilePermissionsEnv = "AWS_RESTRICT_FILE_PERMISSIONS"
 )
 
 var (
@@ -309,6 +311,10 @@ type EnvConfig struct {
 
 	// Priority list of preferred auth scheme names (e.g. sigv4a).
 	AuthSchemePreference []string
+
+	// Controls whether the SDK restricts file permissions on credential
+	// cache files it creates.
+	RestrictFilePermissions aws.RestrictFilePermissions
 }
 
 // loadEnvConfig reads configuration values from the OS's environment variables.
@@ -421,6 +427,10 @@ func NewEnvConfig() (EnvConfig, error) {
 	}
 
 	cfg.AuthSchemePreference = toAuthSchemePreferenceList(os.Getenv(awsAuthSchemePreferenceEnv))
+
+	if err := setRestrictFilePermissionsFromEnvVal(&cfg.RestrictFilePermissions, []string{awsRestrictFilePermissionsEnv}); err != nil {
+		return cfg, err
+	}
 
 	return cfg, nil
 }
@@ -929,4 +939,28 @@ func (c EnvConfig) getAuthSchemePreference() ([]string, bool) {
 		return c.AuthSchemePreference, true
 	}
 	return nil, false
+}
+
+func (c EnvConfig) getRestrictFilePermissions(context.Context) (aws.RestrictFilePermissions, bool, error) {
+	return c.RestrictFilePermissions, len(c.RestrictFilePermissions) > 0, nil
+}
+
+func setRestrictFilePermissionsFromEnvVal(m *aws.RestrictFilePermissions, keys []string) error {
+	for _, k := range keys {
+		value := os.Getenv(k)
+		if len(value) == 0 {
+			continue
+		}
+
+		switch strings.ToLower(value) {
+		case "user_read_write":
+			*m = aws.RestrictFilePermissionsUserReadWrite
+		case "unrestricted":
+			*m = aws.RestrictFilePermissionsUnrestricted
+		default:
+			return fmt.Errorf("invalid value for environment variable, %s=%s, must be user_read_write/unrestricted", k, value)
+		}
+		break
+	}
+	return nil
 }

--- a/config/env_config_test.go
+++ b/config/env_config_test.go
@@ -576,6 +576,29 @@ func TestNewEnvConfig(t *testing.T) {
 				AuthSchemePreference: []string{"sigv4a", "sigv4"},
 			},
 		},
+		55: {
+			Env: map[string]string{
+				"AWS_RESTRICT_FILE_PERMISSIONS": "user_read_write",
+			},
+			Config: EnvConfig{
+				RestrictFilePermissions: aws.RestrictFilePermissionsUserReadWrite,
+			},
+		},
+		56: {
+			Env: map[string]string{
+				"AWS_RESTRICT_FILE_PERMISSIONS": "UNRESTRICTED",
+			},
+			Config: EnvConfig{
+				RestrictFilePermissions: aws.RestrictFilePermissionsUnrestricted,
+			},
+		},
+		57: {
+			Env: map[string]string{
+				"AWS_RESTRICT_FILE_PERMISSIONS": "blabla",
+			},
+			Config:  EnvConfig{},
+			WantErr: true,
+		},
 	}
 
 	for i, c := range cases {

--- a/config/load_options.go
+++ b/config/load_options.go
@@ -240,6 +240,10 @@ type LoadOptions struct {
 	// when constructing clients for specific services. Each callback function receives the service ID
 	// and the service's Options struct, allowing for dynamic configuration based on the service.
 	ServiceOptions []func(string, any)
+
+	// Controls whether the SDK restricts file permissions on credential
+	// cache files it creates.
+	RestrictFilePermissions aws.RestrictFilePermissions
 }
 
 func (o LoadOptions) getDefaultsMode(ctx context.Context) (aws.DefaultsMode, bool, error) {
@@ -1352,4 +1356,16 @@ func (o LoadOptions) getAuthSchemePreference() ([]string, bool) {
 		return o.AuthSchemePreference, true
 	}
 	return nil, false
+}
+
+func (o LoadOptions) getRestrictFilePermissions(context.Context) (aws.RestrictFilePermissions, bool, error) {
+	return o.RestrictFilePermissions, len(o.RestrictFilePermissions) > 0, nil
+}
+
+// WithRestrictFilePermissions sets the RestrictFilePermissions mode on config.
+func WithRestrictFilePermissions(m aws.RestrictFilePermissions) LoadOptionsFunc {
+	return func(o *LoadOptions) error {
+		o.RestrictFilePermissions = m
+		return nil
+	}
 }

--- a/config/provider.go
+++ b/config/provider.go
@@ -784,3 +784,19 @@ func getServiceOptions(ctx context.Context, configs configs) (v []func(string, a
 	}
 	return v, found, err
 }
+
+type restrictFilePermissionsProvider interface {
+	getRestrictFilePermissions(context.Context) (aws.RestrictFilePermissions, bool, error)
+}
+
+func getRestrictFilePermissions(ctx context.Context, configs configs) (value aws.RestrictFilePermissions, found bool, err error) {
+	for _, cfg := range configs {
+		if p, ok := cfg.(restrictFilePermissionsProvider); ok {
+			value, found, err = p.getRestrictFilePermissions(ctx)
+			if err != nil || found {
+				break
+			}
+		}
+	}
+	return
+}

--- a/config/resolve.go
+++ b/config/resolve.go
@@ -442,3 +442,17 @@ func resolveServiceOptions(ctx context.Context, cfg *aws.Config, configs configs
 	cfg.ServiceOptions = serviceOptions
 	return nil
 }
+
+func resolveRestrictFilePermissions(ctx context.Context, cfg *aws.Config, configs configs) error {
+	m, found, err := getRestrictFilePermissions(ctx, configs)
+	if err != nil {
+		return err
+	}
+
+	if !found {
+		m = aws.RestrictFilePermissionsUserReadWrite
+	}
+
+	cfg.RestrictFilePermissions = m
+	return nil
+}

--- a/config/resolve_credentials.go
+++ b/config/resolve_credentials.go
@@ -640,6 +640,7 @@ func resolveLoginCredentials(ctx context.Context, cfg *aws.Config, sharedCfg *Sh
 	svc := signin.NewFromConfig(*cfg)
 	provider := logincreds.New(svc, tokenPath, func(o *logincreds.Options) {
 		o.CredentialSources = getCredentialSources(ctx)
+		o.RestrictPermissions = cfg.RestrictFilePermissions != aws.RestrictFilePermissionsUnrestricted
 	})
 	cfg.Credentials, err = wrapWithCredentialsCache(ctx, configs, provider)
 	if err != nil {

--- a/credentials/logincreds/file.go
+++ b/credentials/logincreds/file.go
@@ -9,6 +9,6 @@ var openFile func(string) (io.ReadCloser, error) = func(name string) (io.ReadClo
 	return os.Open(name)
 }
 
-var createFile func(string) (io.WriteCloser, error) = func(name string) (io.WriteCloser, error) {
-	return os.Create(name)
+var createFile func(string, os.FileMode) (io.WriteCloser, error) = func(name string, mode os.FileMode) (io.WriteCloser, error) {
+	return os.OpenFile(name, os.O_RDWR|os.O_CREATE|os.O_TRUNC, mode)
 }

--- a/credentials/logincreds/provider.go
+++ b/credentials/logincreds/provider.go
@@ -42,6 +42,10 @@ type Options struct {
 	// The path to the cached login token.
 	CachedTokenFilepath string
 
+	// Whether to restrict file permissions on newly-written cache files.
+	// When true, files are created with 0600 on Unix.
+	RestrictPermissions bool
+
 	// The chain of providers that was used to create this provider.
 	//
 	// These values are for reporting purposes and are not meant to be set up
@@ -145,7 +149,15 @@ func (p *Provider) saveToken(token *loginToken) error {
 		return err
 	}
 
-	f, err := createFile(p.options.CachedTokenFilepath)
+	mode := os.FileMode(0666) // matches that used by os.Create
+	if p.options.RestrictPermissions {
+		mode = 0600
+	}
+
+	// createFile DOES NOT re-create the file with new permissions if it
+	// already exists, so in that scenario any existing permissions are
+	// preserved
+	f, err := createFile(p.options.CachedTokenFilepath, mode)
 	if err != nil {
 		return err
 	}

--- a/credentials/logincreds/provider_test.go
+++ b/credentials/logincreds/provider_test.go
@@ -74,7 +74,7 @@ func mockCreateFile(terr error) (*writer, func()) {
 	w := &writer{}
 
 	orig := createFile
-	createFile = func(name string) (io.WriteCloser, error) {
+	createFile = func(name string, mode os.FileMode) (io.WriteCloser, error) {
 		if terr != nil {
 			return nil, terr
 		}


### PR DESCRIPTION
* NEW cache files are created with 0600. existing files are untouched
* add support for `AWS_RESTRICT_FILE_PERMISSIONS`
  * the SEP did not specify a shared config and internal discussion apparently reached consensus that such a config was overkill, so that's why that's missing