### PR TITLE
fix: skip clock skew calculation for cached responses (Age header)

### DIFF
--- a/aws/middleware/middleware.go
+++ b/aws/middleware/middleware.go
@@ -62,6 +62,14 @@ func (a RecordResponseTiming) HandleDeserialize(ctx context.Context, in middlewa
 
 	switch resp := out.RawResponse.(type) {
 	case *smithyhttp.Response:
+		// If the response has an Age header, it was served from a cache (e.g.
+		// CloudFront). In that case the Date header reflects when the original
+		// response was generated, not the current server time, so using it for
+		// clock-skew calculation would produce incorrect results. Skip skew
+		// computation entirely for cached responses.
+		if resp.Header.Get("Age") != "" {
+			break
+		}
 		respDateHeader := resp.Header.Get("Date")
 		if len(respDateHeader) == 0 {
 			break

--- a/aws/middleware/middleware_test.go
+++ b/aws/middleware/middleware_test.go
@@ -144,6 +144,26 @@ func TestAttemptClockSkewHandler(t *testing.T) {
 			ExpectServerTime:  time.Date(2020, 3, 5, 22, 25, 15, 0, time.UTC),
 			ExpectAttemptSkew: -2 * time.Second,
 		},
+		"cached response with Age header skips skew": {
+			Next: func(ctx context.Context, in smithymiddleware.DeserializeInput,
+			) (out smithymiddleware.DeserializeOutput, m smithymiddleware.Metadata, err error) {
+				out.RawResponse = &smithyhttp.Response{
+					Response: &http.Response{
+						StatusCode: 200,
+						Header: http.Header{
+							"Date": []string{"Thu, 05 Mar 2020 12:00:00 GMT"},
+							"Age":  []string{"14400"},
+						},
+					},
+				}
+				return out, m, err
+			},
+			ResponseAt: func() time.Time {
+				return time.Date(2020, 3, 5, 22, 25, 17, 0, time.UTC)
+			},
+			ExpectResponseAt: time.Date(2020, 3, 5, 22, 25, 17, 0, time.UTC),
+			// ServerTime and AttemptSkew should NOT be set for cached responses
+		},
 	}
 
 	for name, c := range cases {


### PR DESCRIPTION
## Problem

When a response is served from a cache (e.g. CloudFront), the `Date` header reflects when the original response was **generated**, not when it is being **served**. The SDK's `RecordResponseTiming` middleware uses this `Date` header to compute clock skew, which produces incorrect results for cached responses.

Once skew is calculated incorrectly, the next AWS call fails with a signature expiration error. The failing response then has a correct `Date` header, so subsequent calls succeed — but every first call after a cached response fails.

See #3409 for full reproduction steps and raw HTTP traces.

## Fix

Check for the standard HTTP `Age` header in `RecordResponseTiming.HandleDeserialize`. When present, skip clock skew computation entirely, as the `Date` header is unreliable for skew calculation on cached responses.

This approach was suggested by @lucix-aws in [#3409](https://github.com/aws/aws-sdk-go-v2/issues/3409#issuecomment-2922840717):
> We will likely just specify to check for an Age header and if so disregard any potential skew for that request.

## Changes

- `aws/middleware/middleware.go`: Add `Age` header check before computing skew
- `aws/middleware/middleware_test.go`: Add test case for cached response with `Age` header

Fixes #3409
