### PR TITLE
fix(feature/s3/transfermanager): allow multiple symlinks to share the same target file in UploadDirectory

### DIFF
--- a/feature/s3/transfermanager/api_op_UploadDirectory.go
+++ b/feature/s3/transfermanager/api_op_UploadDirectory.go
@@ -130,7 +130,6 @@ type directoryUploader struct {
 
 	filesUploaded atomic.Int64
 	filesFailed   atomic.Int64
-	traversed     map[string]any
 
 	err error
 
@@ -151,7 +150,7 @@ func (u *directoryUploader) uploadDirectory(ctx context.Context) (*UploadDirecto
 	}
 
 	if aws.ToBool(u.in.Recursive) {
-		u.traverse(aws.ToString(u.in.Source), aws.ToString(u.in.KeyPrefix), ch)
+		u.traverse(aws.ToString(u.in.Source), aws.ToString(u.in.KeyPrefix), ch, map[string]struct{}{})
 	} else {
 		files, err := u.traverseFolder(aws.ToString(u.in.Source))
 		if err != nil {
@@ -210,8 +209,6 @@ func (u *directoryUploader) uploadDirectory(ctx context.Context) (*UploadDirecto
 }
 
 func (u *directoryUploader) init() {
-	u.traversed = make(map[string]any)
-
 	u.failurePolicy = TerminateUploadPolicy{}
 	if u.in.FailurePolicy != nil {
 		u.failurePolicy = u.in.FailurePolicy
@@ -228,8 +225,15 @@ type fileEntry struct {
 }
 
 // traverse recursively visits each folder and sends each
-// valid file's request to worker goroutines
-func (u *directoryUploader) traverse(path, keyPrefix string, ch chan fileEntry) {
+// valid file's request to worker goroutines.
+//
+// ancestors tracks the real directory paths currently active on the call
+// stack. It is used to detect symlinks that would create an infinite loop by
+// pointing back to a directory that is already being recursed into. Entries
+// are added before recursing into a directory and removed afterward (DFS
+// backtracking), so two sibling symlinks that resolve to the same directory
+// are each traversed independently without triggering a false positive.
+func (u *directoryUploader) traverse(path, keyPrefix string, ch chan fileEntry, ancestors map[string]struct{}) {
 	if u.getErr() != nil {
 		return
 	}
@@ -256,14 +260,24 @@ func (u *directoryUploader) traverse(path, keyPrefix string, ch chan fileEntry) 
 		return
 	}
 	if fileInfo.IsDir() {
+		// Detect symlink-induced directory loops: if absPath is already an
+		// ancestor on the current recursion stack we would loop forever.
+		if _, loop := ancestors[absPath]; loop {
+			u.setErr(fmt.Errorf("traversed duplicate path %s", absPath))
+			return
+		}
 		subFiles, err := u.traverseFolder(absPath)
 		if err != nil {
 			u.setErr(fmt.Errorf("error when traversing folder %s: %v", absPath, err))
 			return
 		}
+		// Mark this directory as active for all children, then unmark it
+		// once done so sibling subtrees can legitimately enter the same dir.
+		ancestors[absPath] = struct{}{}
 		for _, f := range subFiles {
-			u.traverse(filepath.Join(path, f), key, ch)
+			u.traverse(filepath.Join(path, f), key, ch, ancestors)
 		}
+		delete(ancestors, absPath)
 	} else {
 		if u.in.Filter != nil && !u.in.Filter.FilterFile(path) {
 			return
@@ -272,13 +286,8 @@ func (u *directoryUploader) traverse(path, keyPrefix string, ch chan fileEntry) 
 	}
 }
 
-// getAbsPath resolves a path's destination absolute path with deduplication
-// in case any symlink causes a directory traversal loop.
-//
-// Only directory paths are tracked in u.traversed. Multiple distinct symlinks
-// may legitimately resolve to the same underlying file; they represent separate
-// S3 objects (with different keys) and should all be uploaded. Tracking only
-// directories is sufficient to prevent infinite traversal loops.
+// getAbsPath resolves a path's destination absolute path, following symlinks
+// when FollowSymbolicLinks is enabled.
 func (u *directoryUploader) getAbsPath(path string) (string, error) {
 	fileInfo, err := os.Lstat(path)
 	if err != nil {
@@ -293,19 +302,6 @@ func (u *directoryUploader) getAbsPath(path string) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		// Re-stat the resolved target to determine whether it is a directory.
-		fileInfo, err = os.Lstat(path)
-		if err != nil {
-			return "", fmt.Errorf("error when stating resolved path %s: %v", path, err)
-		}
-	}
-
-	// Only deduplicate directory paths to prevent traversal loops.
-	if fileInfo.IsDir() {
-		if u.traversed[path] != nil {
-			return "", fmt.Errorf("traversed duplicate path %s", path)
-		}
-		u.traversed[path] = struct{}{}
 	}
 
 	return path, nil

--- a/feature/s3/transfermanager/api_op_UploadDirectory.go
+++ b/feature/s3/transfermanager/api_op_UploadDirectory.go
@@ -272,8 +272,13 @@ func (u *directoryUploader) traverse(path, keyPrefix string, ch chan fileEntry) 
 	}
 }
 
-// getAbsPath resolves a path's desination absolute path with deduplication
-// in case any symlink causes traverse loop or repeated upload
+// getAbsPath resolves a path's destination absolute path with deduplication
+// in case any symlink causes a directory traversal loop.
+//
+// Only directory paths are tracked in u.traversed. Multiple distinct symlinks
+// may legitimately resolve to the same underlying file; they represent separate
+// S3 objects (with different keys) and should all be uploaded. Tracking only
+// directories is sufficient to prevent infinite traversal loops.
 func (u *directoryUploader) getAbsPath(path string) (string, error) {
 	fileInfo, err := os.Lstat(path)
 	if err != nil {
@@ -288,11 +293,20 @@ func (u *directoryUploader) getAbsPath(path string) (string, error) {
 		if err != nil {
 			return "", err
 		}
+		// Re-stat the resolved target to determine whether it is a directory.
+		fileInfo, err = os.Lstat(path)
+		if err != nil {
+			return "", fmt.Errorf("error when stating resolved path %s: %v", path, err)
+		}
 	}
-	if u.traversed[path] != nil {
-		return "", fmt.Errorf("traversed duplicate path %s", path)
+
+	// Only deduplicate directory paths to prevent traversal loops.
+	if fileInfo.IsDir() {
+		if u.traversed[path] != nil {
+			return "", fmt.Errorf("traversed duplicate path %s", path)
+		}
+		u.traversed[path] = struct{}{}
 	}
-	u.traversed[path] = struct{}{}
 
 	return path, nil
 }
@@ -318,6 +332,10 @@ func (u *directoryUploader) traverseFolder(path string) ([]string, error) {
 
 func (u *directoryUploader) traverseSymlink(path string) (string, error) {
 	originPath := path
+	// visited is local to this resolution chain and detects circular symlink
+	// references (e.g. a → b → a) without interfering with other symlinks that
+	// may legitimately resolve to the same target.
+	visited := map[string]struct{}{path: {}}
 	for {
 		dst, err := os.Readlink(path)
 		if err != nil {
@@ -328,7 +346,7 @@ func (u *directoryUploader) traverseSymlink(path string) (string, error) {
 		} else {
 			path = filepath.Join(filepath.Dir(path), dst)
 		}
-		if u.traversed[path] != nil {
+		if _, seen := visited[path]; seen {
 			return "", fmt.Errorf("traversed duplicate path: %s", path)
 		}
 		fileInfo, err := os.Lstat(path)
@@ -338,7 +356,7 @@ func (u *directoryUploader) traverseSymlink(path string) (string, error) {
 		if fileInfo.Mode()&os.ModeSymlink != os.ModeSymlink {
 			return path, nil
 		}
-		u.traversed[path] = struct{}{}
+		visited[path] = struct{}{}
 	}
 }
 

--- a/feature/s3/transfermanager/upload_directory_test.go
+++ b/feature/s3/transfermanager/upload_directory_test.go
@@ -325,7 +325,10 @@ func TestUploadDirectory(t *testing.T) {
 				l.expectFailed(t, in, err)
 			},
 		},
-		"error when a symlink refers to another file under source": {
+		// A symlink that resolves to a file already present elsewhere in the
+		// source tree represents a distinct S3 object (different key) and
+		// should be uploaded successfully alongside the original file.
+		"symlink pointing to another file already in source is uploaded": {
 			source:         filepath.Join(root, "multi-file-contain-symlink"),
 			followSymLinks: true,
 			recursive:      true,
@@ -340,9 +343,40 @@ func TestUploadDirectory(t *testing.T) {
 				}
 				return postprocessFunc, nil
 			},
-			expectErr: "traversed duplicate path",
+			expectKeys:          []string{"foo", "bar", "to/baz", "to/the/symLoop", "to/the/yee"},
+			expectFilesUploaded: 5,
 			listenerValidationFn: func(t *testing.T, l *mockDirectoryListener, in, out any, err error) {
-				l.expectFailed(t, in, err)
+				l.expectStart(t, in)
+				l.expectComplete(t, in, out, 5)
+			},
+		},
+		// Multiple distinct symlinks pointing to the same underlying file must
+		// each be uploaded as a separate S3 object (issue #3439).
+		"multiple symlinks pointing to the same target file are each uploaded": {
+			source:         filepath.Join(root, "multi-file-contain-symlink"),
+			followSymLinks: true,
+			recursive:      true,
+			preprocessFunc: func(root string) (func() error, error) {
+				symlinkPath1 := filepath.Join(root, "multi-file-contain-symlink", "to", "the", "symLink1")
+				symlinkPath2 := filepath.Join(root, "multi-file-contain-symlink", "to", "the", "symLink2")
+				postprocessFunc := func() error {
+					os.Remove(symlinkPath1)
+					os.Remove(symlinkPath2)
+					return nil
+				}
+				if err := os.Symlink(filepath.Join(root, "dstFile1"), symlinkPath1); err != nil {
+					return postprocessFunc, err
+				}
+				if err := os.Symlink(filepath.Join(root, "dstFile1"), symlinkPath2); err != nil {
+					return postprocessFunc, err
+				}
+				return postprocessFunc, nil
+			},
+			expectKeys:          []string{"foo", "bar", "to/baz", "to/the/symLink1", "to/the/symLink2", "to/the/yee"},
+			expectFilesUploaded: 6,
+			listenerValidationFn: func(t *testing.T, l *mockDirectoryListener, in, out any, err error) {
+				l.expectStart(t, in)
+				l.expectComplete(t, in, out, 6)
 			},
 		},
 		"error when source is not directory": {

--- a/feature/s3/transfermanager/upload_directory_test.go
+++ b/feature/s3/transfermanager/upload_directory_test.go
@@ -212,6 +212,40 @@ func TestUploadDirectory(t *testing.T) {
 				l.expectComplete(t, in, out, 4)
 			},
 		},
+		// Two distinct directory symlinks that point to the same underlying directory
+		// must each be traversed and uploaded as separate S3 key subtrees.
+		// Regression test for the edge case raised during review of #3439.
+		"two symlinks referring to the same directory are each uploaded": {
+			source:         filepath.Join(root, "multi-file-contain-symlink"),
+			followSymLinks: true,
+			recursive:      true,
+			preprocessFunc: func(root string) (func() error, error) {
+				symlinkPath1 := filepath.Join(root, "multi-file-contain-symlink", "to", "the", "symlinkDirA")
+				symlinkPath2 := filepath.Join(root, "multi-file-contain-symlink", "to", "the", "symlinkDirB")
+				postprocessFunc := func() error {
+					os.Remove(symlinkPath1)
+					os.Remove(symlinkPath2)
+					return nil
+				}
+				// Both symlinks point to the exact same directory (dstDir1 contains one file: foo)
+				if err := os.Symlink(filepath.Join(root, "dstDir1"), symlinkPath1); err != nil {
+					return postprocessFunc, err
+				}
+				if err := os.Symlink(filepath.Join(root, "dstDir1"), symlinkPath2); err != nil {
+					return postprocessFunc, err
+				}
+				return postprocessFunc, nil
+			},
+			// dstDir1 contains one file (foo), so each directory symlink contributes one key:
+			//   to/the/symlinkDirA/foo  and  to/the/symlinkDirB/foo
+			// plus the original 4 files in multi-file-contain-symlink = 6 total
+			expectKeys:          []string{"foo", "bar", "to/baz", "to/the/yee", "to/the/symlinkDirA/foo", "to/the/symlinkDirB/foo"},
+			expectFilesUploaded: 6,
+			listenerValidationFn: func(t *testing.T, l *mockDirectoryListener, in, out any, err error) {
+				l.expectStart(t, in)
+				l.expectComplete(t, in, out, 6)
+			},
+		},
 		"folder containing files and symlink referring to folder": {
 			source:         filepath.Join(root, "multi-file-contain-symlink"),
 			followSymLinks: true,


### PR DESCRIPTION
## Description

Fixes #3439

`UploadDirectory` with `FollowSymbolicLinks: true` fails with `traversed duplicate path` when two or more distinct symlinks inside the source directory resolve to the same underlying file or directory (e.g. a Hugging Face model cache where multiple snapshot entries point to the same blob).

Each symlink represents a distinct S3 key subtree and all uploads are valid and expected. The error was a false positive.

## Root Cause

`u.traversed` was used as a global session-wide registry for resolved paths. When any symlink resolved to a path already in the map, whether a file or a directory, the upload failed. This caused false positives whenever two distinct symlinks pointed to the same underlying file or directory, both of which are legitimate and should produce separate S3 objects under different keys.

## Fix

- Removed `u.traversed` entirely.
- Directory loop detection now uses an `ancestors` set passed through recursive `traverse` calls. A directory is added to `ancestors` before recursing into its children and removed afterward (DFS backtracking). This means only directories **currently active on the call stack** are checked for cycles, which correctly allows sibling symlinks to the same directory while still detecting actual infinite loops.
- `traverseSymlink` retains its existing **local `visited` set** per resolution chain to detect circular symlink chains (e.g. `a → b → a`), without any cross-contamination between independent symlink resolutions.

## Testing

- Added three new test cases to `TestUploadDirectory`:
  - `"symlink pointing to another file already in source is uploaded"`: a symlink resolving to a file that exists elsewhere in the source tree should succeed, not error.
  - `"multiple symlinks pointing to the same target file are each uploaded"`: directly reproduces the scenario in #3439.
  - `"two symlinks referring to the same directory are each uploaded"`: covers the edge case where two sibling symlinks resolve to the same directory; both subtrees must be uploaded independently.
- The previously incorrect test case `"error when a symlink refers to another file under source"` has been replaced, as that behaviour was wrong.
- All existing tests continue to pass, including the legitimate loop-detection case `"error when a symlink refers to its upper dir"`.
