### PR TITLE
config: accept login_session profiles as an assume role source_profile

### DIFF
--- a/config/shared_config.go
+++ b/config/shared_config.go
@@ -1463,6 +1463,7 @@ func (c *SharedConfig) hasCredentials() bool {
 	case len(c.CredentialSource) != 0:
 	case len(c.CredentialProcess) != 0:
 	case len(c.WebIdentityTokenFile) != 0:
+	case len(c.LoginSession) != 0:
 	case c.hasSSOConfiguration():
 	case c.Credentials.HasKeys():
 	default:

--- a/config/shared_config_test.go
+++ b/config/shared_config_test.go
@@ -134,6 +134,19 @@ func TestNewSharedConfig(t *testing.T) {
 				RoleARN: "assume_role_wo_creds_role_arn",
 			},
 		},
+		"Assume role with login session source profile": {
+			ConfigFilenames: []string{testConfigFilename},
+			Profile:         "assume_role_w_login_session",
+			Expected: SharedConfig{
+				Profile:           "assume_role_w_login_session",
+				RoleARN:           "assume_role_w_login_session_role_arn",
+				SourceProfileName: "login_session_creds",
+				Source: &SharedConfig{
+					Profile:      "login_session_creds",
+					LoginSession: "login_session_creds_session",
+				},
+			},
+		},
 		"Invalid INI file": {
 			ConfigFilenames: []string{filepath.Join("testdata", "shared_config_invalid_ini")},
 			Profile:         "profile_name",

--- a/config/testdata/shared_config
+++ b/config/testdata/shared_config
@@ -90,6 +90,13 @@ aws_secret_access_key = assume_role_w_creds_secret
 role_arn = assume_role_wo_creds_role_arn
 source_profile = assume_role_wo_creds
 
+[profile login_session_creds]
+login_session = login_session_creds_session
+
+[profile assume_role_w_login_session]
+role_arn = assume_role_w_login_session_role_arn
+source_profile = login_session_creds
+
 [profile valid_arn_region]
 s3_use_arn_region=true
 


### PR DESCRIPTION
### Summary

Fixes #3446

A profile using `login_session` (aws login credentials) cannot be used as the `source_profile` of an assume-role profile. `config.LoadDefaultConfig` fails with:

> failed to load assume role &lt;role-arn&gt;, of profile &lt;source&gt;, &lt;nil&gt;

`aws login` support (#3230) added `login_session` as a *direct* credential provider, but `SharedConfig.hasCredentials()` - which validates that a linked source profile actually supplies credentials - wasn't updated to recognise it. As a result a login-session source profile is treated as having no credentials and the assume-role chain fails to load. The AWS CLI / botocore resolve the same configuration successfully.

A single profile combining `login_session` + `role_arn` (no `source_profile`) already works, because that path doesn't go through the source-profile validation; only the `source_profile` form is affected.

### Fix
Fix this by including a check for `c.LoginSession` in `hasCredentials()` to add to the checks for the various other credential sources.