### PR TITLE
fix(rds/auth): include path slash in BuildAuthToken presigned URL

### DIFF
--- a/feature/rds/auth/connect.go
+++ b/feature/rds/auth/connect.go
@@ -69,6 +69,8 @@ func BuildAuthToken(ctx context.Context, endpoint, region, dbUser string, creds 
 	if err != nil {
 		return "", err
 	}
+	// Match aws rds generate-db-auth-token URL shape (path must be "/" before query).
+	req.URL.Path = "/"
 	values := req.URL.Query()
 	values.Set("Action", "connect")
 	values.Set("DBUser", dbUser)

--- a/feature/rds/auth/connect_test.go
+++ b/feature/rds/auth/connect_test.go
@@ -22,13 +22,13 @@ func TestBuildAuthToken(t *testing.T) {
 			endpoint:      "https://prod-instance.us-east-1.rds.amazonaws.com:3306",
 			region:        "us-west-2",
 			user:          "mysqlUser",
-			expectedRegex: `^prod-instance\.us-east-1\.rds\.amazonaws\.com:3306\?Action=connect.*?DBUser=mysqlUser.*`,
+			expectedRegex: `^prod-instance\.us-east-1\.rds\.amazonaws\.com:3306/\?Action=connect.*?DBUser=mysqlUser.*`,
 		},
 		{
 			endpoint:      "prod-instance.us-east-1.rds.amazonaws.com:3306",
 			region:        "us-west-2",
 			user:          "mysqlUser",
-			expectedRegex: `^prod-instance\.us-east-1\.rds\.amazonaws\.com:3306\?Action=connect.*?DBUser=mysqlUser.*`,
+			expectedRegex: `^prod-instance\.us-east-1\.rds\.amazonaws\.com:3306/\?Action=connect.*?DBUser=mysqlUser.*`,
 		},
 		{
 			endpoint:      "prod-instance.us-east-1.rds.amazonaws.com",


### PR DESCRIPTION
Fixes #3365