### PR TITLE
aws/transport/http: set TLS curve preferences

### DIFF
--- a/aws/transport/http/client.go
+++ b/aws/transport/http/client.go
@@ -193,9 +193,13 @@ func defaultHTTPTransport() *http.Transport {
 		ForceAttemptHTTP2:     true,
 		TLSClientConfig: &tls.Config{
 			MinVersion: DefaultHTTPTransportTLSMinVersion,
+			CurvePreferences: []tls.CurveID{
+				tls.CurveP256,
+				tls.CurveP384,
+				tls.CurveP521,
+			},
 		},
 	}
-
 	return tr
 }
 

--- a/aws/transport/http/client_test.go
+++ b/aws/transport/http/client_test.go
@@ -1,8 +1,10 @@
 package http
 
 import (
+	"crypto/tls"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -156,5 +158,41 @@ func TestBuildableClient_KeepsSecurityTokenOnSameHost(t *testing.T) {
 
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("expect 200 code, got %d", resp.StatusCode)
+	}
+}
+func TestDefaultHTTPTransportTLSConfig(t *testing.T) {
+	tr := defaultHTTPTransport()
+
+	if tr.TLSClientConfig == nil {
+		t.Fatal("expected TLSClientConfig to be initialized")
+	}
+
+	if tr.TLSClientConfig.MinVersion != tls.VersionTLS12 {
+		t.Fatalf(
+			"expected TLS min version %v, got %v",
+			tls.VersionTLS12,
+			tr.TLSClientConfig.MinVersion,
+		)
+	}
+}
+func TestDefaultHTTPTransportCurvePreferences(t *testing.T) {
+	tr := defaultHTTPTransport()
+
+	if tr.TLSClientConfig == nil {
+		t.Fatal("expected TLSClientConfig")
+	}
+
+	expected := []tls.CurveID{
+		tls.CurveP256,
+		tls.CurveP384,
+		tls.CurveP521,
+	}
+
+	if !reflect.DeepEqual(tr.TLSClientConfig.CurvePreferences, expected) {
+		t.Fatalf(
+			"expected curve preferences %v, got %v",
+			expected,
+			tr.TLSClientConfig.CurvePreferences,
+		)
 	}
 }


### PR DESCRIPTION
## Summary

This change updates the default HTTP transport configuration to explicitly set TLS curve preferences.

## Changes

- Added TLS curve preferences to `tls.Config` in `defaultHTTPTransport`:
  - CurveP256
  - CurveP384
  - CurveP521

- Ensures consistent elliptic curve selection for TLS connections.

- Added unit test to validate:
  - TLS minimum version is TLS 1.2
  - TLS configuration is properly initialized

## Motivation

Improves TLS configuration clarity and ensures predictable elliptic curve usage in secure connections.

## Testing

- Ran `go test ./aws/transport/http`
- All tests passing locally

## Notes

No changes to generated code or service models.