### PR TITLE
Set transfer manager error as the first error seen, preventing race condition

### DIFF
--- a/.changelog/d5beab3a563a42d8aefec9771f292128.json
+++ b/.changelog/d5beab3a563a42d8aefec9771f292128.json
@@ -1,0 +1,8 @@
+{
+    "id": "d5beab3a-563a-42d8-aefe-c9771f292128",
+    "type": "bugfix",
+    "description": "Fix Transfer Manager error logic to preserve the first error found",
+    "modules": [
+        "feature/s3/transfermanager"
+    ]
+}

--- a/feature/s3/transfermanager/api_op_UploadObject.go
+++ b/feature/s3/transfermanager/api_op_UploadObject.go
@@ -1174,7 +1174,9 @@ func (u *multiUploader) seterr(e error) {
 	u.m.Lock()
 	defer u.m.Unlock()
 
-	u.err = e
+	if u.err == nil {
+		u.err = e
+	}
 }
 
 func (u *multiUploader) fail(ctx context.Context, clientOptions ...func(*s3.Options)) {

--- a/feature/s3/transfermanager/api_op_UploadObject_test.go
+++ b/feature/s3/transfermanager/api_op_UploadObject_test.go
@@ -1131,6 +1131,89 @@ func TestUploadWithContextCanceledWhenUploadPart(t *testing.T) {
 	}
 }
 
+// TestUploadFirstErrorWins verifies that when an UploadPart error races with a
+// context-cancellation read error, the final reported error is always the
+// UploadPart error (the root cause), not the secondary read error.
+//
+// The contextAwareBody forces the producer goroutine to block in readFillBuf
+// until the context is canceled, then return the context error. This guarantees
+// the producer calls seterr with "read multipart upload data failed" while the
+// worker concurrently calls seterr with the UploadPart error — exercising the
+// first-error-wins invariant in seterr.
+func TestUploadFirstErrorWins(t *testing.T) {
+	ctx := &awstesting.FakeContext{DoneCh: make(chan struct{})}
+	ctx.Error = fmt.Errorf("secondary context error")
+	c, _, _ := s3testing.NewUploadLoggingClient(nil)
+	var index atomic.Int64
+	var once sync.Once
+
+	// contextAwareBody returns data for the first two parts, then blocks
+	// until the context is canceled — at which point it returns ctx.Error.
+	// This forces the producer goroutine through the shouldContinue →
+	// "read multipart upload data failed" → seterr path while the worker
+	// is concurrently calling seterr with the UploadPart error.
+	body := &contextAwareBody{
+		ctx:       ctx,
+		data:      make([]byte, 24*1024*1024),
+		threshold: 16*1024*1024 + 1, // enough for 2 full parts
+	}
+
+	c.UploadPartFn = func(context.Context, *s3testing.TransferManagerLoggingClient, *s3.UploadPartInput) (out *s3.UploadPartOutput, err error) {
+		if idx := index.Load(); idx > 0 {
+			once.Do(func() {
+				close(ctx.DoneCh)
+				err = fmt.Errorf("primary upload part error")
+			})
+		}
+		out = &s3.UploadPartOutput{}
+		index.Add(1)
+		return
+	}
+	u := New(c, func(o *Options) {
+		o.FailTimeout = 5 * time.Second
+	})
+
+	_, err := u.UploadObject(ctx, &UploadObjectInput{
+		Bucket: aws.String("Bucket"),
+		Key:    aws.String("Key"),
+		Body:   body,
+	})
+	if err == nil {
+		t.Fatal("expect error, got nil")
+	}
+	if strings.Contains(err.Error(), "secondary context error") {
+		t.Fatalf("secondary error leaked into output: %v", err)
+	}
+	if !strings.Contains(err.Error(), "primary upload part error") {
+		t.Fatalf("expected primary error in output, got: %v", err)
+	}
+}
+
+// contextAwareBody serves data normally until threshold bytes have been read,
+// then blocks until the context is canceled and returns the context error.
+// This simulates a network body that fails when the request context is canceled.
+type contextAwareBody struct {
+	ctx       *awstesting.FakeContext
+	data      []byte
+	offset    int
+	threshold int
+}
+
+func (r *contextAwareBody) Read(p []byte) (int, error) {
+	if r.offset >= r.threshold {
+		<-r.ctx.DoneCh
+		return 0, r.ctx.Error
+	}
+	remaining := r.threshold - r.offset
+	n := len(p)
+	if n > remaining {
+		n = remaining
+	}
+	copy(p[:n], r.data[r.offset:r.offset+n])
+	r.offset += n
+	return n, nil
+}
+
 func TestUploadWithContextCanceledWhenComplete(t *testing.T) {
 	ctx := &awstesting.FakeContext{DoneCh: make(chan struct{})}
 	ctx.Error = fmt.Errorf("context canceled error which shouldn't be returned finally")


### PR DESCRIPTION
 Here's the PR description:

  ## Fix flaky multipart upload error reporting due to seterr race condition

  ### Problem
 If there are multiple goroutines writing to `seterr`,  `multiUploader.seterr()` doesn't check if it has already received an error, which means when multiple goroutines race to report errors, the **last writer wins** rather than the first. During multipart uploads, this causes the root-cause error (e.g., an `UploadPart` failure) to be overwritten by a secondary error (e.g., a context-cancellation read error triggered as a consequence of the first failure).

  ### Root Cause

  The multipart upload has two concurrent writers to `seterr`:
  1. **Worker goroutines** — call `seterr` when `UploadPart` returns an error
  2. **Producer goroutine** — calls `seterr` when `nextReader` fails (e.g., body read returns context error after cancellation)

  The causal chain is always: UploadPart fails → context gets canceled → body read fails. But because `seterr` blindly overwrites, the producer's secondary error can replace the worker's root-cause error depending on goroutine scheduling.

  ### Fix

  Change `seterr` to only store the **first** error (compare-and-swap semantics):

  ```go
  func (u *multiUploader) seterr(e error) {
      u.m.Lock()
      defer u.m.Unlock()
      if u.err == nil {
          u.err = e
      }
  }
  ```

This follows the same "first error wins" pattern used by errgroup and other Go concurrency primitives, preserving the root cause and discarding downstream symptoms.

 ### Testing

Added TestUploadFirstErrorWins which uses a contextAwareBody to deterministically reproduce the race:

  - The body serves data for the first two parts, then blocks until context cancellation
  - A worker cancels the context and returns an error from UploadPart
  - The body unblocks and returns the context error
  - Both goroutines race to call seterr

  The test asserts the primary (UploadPart) error is always reported and the secondary (context) error never leaks through. Without the fix, this test fails on the first run.
