### PR TITLE
feat: multi-attribute support for expression key builder

### DIFF
--- a/feature/dynamodb/expression/key_condition.go
+++ b/feature/dynamodb/expression/key_condition.go
@@ -2,6 +2,8 @@ package expression
 
 import (
 	"fmt"
+	"slices"
+	"strings"
 )
 
 // keyConditionMode specifies the types of the struct KeyConditionBuilder,
@@ -297,40 +299,59 @@ func (kb KeyBuilder) GreaterThanEqual(valueBuilder ValueBuilder) KeyConditionBui
 }
 
 // KeyAnd returns a KeyConditionBuilder representing the logical AND clause
-// of the two argument KeyConditionBuilders. The resulting KeyConditionBuilder
-// can be used as an argument to the WithKeyCondition() method for the Builder
-// struct.
+// of the argument KeyConditionBuilders. It accepts two or more conditions,
+// enabling key condition expressions for multi-attribute key GSIs. All
+// conditions except the last must be equality conditions. If the first
+// argument is itself an AND condition, its children are flattened into the
+// result. The resulting KeyConditionBuilder can be used as an argument to the
+// WithKeyCondition() method for the Builder struct.
 //
-// Example:
+// Example with partition key and sort key condition:
 //
-//	// keyCondition represents the key condition where the partition key
-//	// "TeamName" is equal to value "Wildcats" and sort key "Number" is equal
-//	// to value 1
 //	keyCondition := expression.KeyAnd(expression.Key("TeamName").Equal(expression.Value("Wildcats")), expression.Key("Number").Equal(expression.Value(1)))
-//
-//	// Used to make an Builder
 //	builder := expression.NewBuilder().WithKeyCondition(keyCondition)
 //
 // Expression Equivalent:
 //
-//	expression.KeyAnd(expression.Key("TeamName").Equal(expression.Value("Wildcats")), expression.Key("Number").Equal(expression.Value(1)))
-//	// Let #NUMBER, :teamName, and :one be ExpressionAttributeName and
-//	// ExpressionAttributeValues representing the item attribute "Number",
-//	// the value "Wildcats", and the value 1
 //	"(TeamName = :teamName) AND (#NUMBER = :one)"
-func KeyAnd(left, right KeyConditionBuilder) KeyConditionBuilder {
-	if left.mode != equalKeyCond {
+//
+// Example with multi-attribute key GSI:
+//
+//	keyCondition := expression.KeyAnd(expression.Key("TournamentId").Equal(expression.Value("WINTER2024")), expression.Key("Region").Equal(expression.Value("NA-EAST")), expression.Key("Round").GreaterThan(expression.Value(1)))
+//	builder := expression.NewBuilder().WithKeyCondition(keyCondition)
+//
+// Expression Equivalent:
+//
+//	"(TournamentId = :tournamentId) AND (Region = :region) AND (#ROUND > :one)"
+func KeyAnd(keyConditions ...KeyConditionBuilder) KeyConditionBuilder {
+	if len(keyConditions) < 2 {
 		return KeyConditionBuilder{
 			mode: invalidKeyCond,
 		}
 	}
-	if right.mode == andKeyCond {
+
+	// Flatten a chained AND on the left (supports .And().And() usage)
+	if keyConditions[0].mode == andKeyCond {
+		keyConditions = slices.Concat(keyConditions[0].keyConditionList, keyConditions[1:])
+	}
+
+	for _, keyCondition := range keyConditions[:len(keyConditions)-1] {
+		if keyCondition.mode != equalKeyCond {
+			return KeyConditionBuilder{
+				mode: invalidKeyCond,
+			}
+		}
+
+	}
+
+	if keyConditions[len(keyConditions)-1].mode == andKeyCond {
 		return KeyConditionBuilder{
 			mode: invalidKeyCond,
 		}
 	}
+
 	return KeyConditionBuilder{
-		keyConditionList: []KeyConditionBuilder{left, right},
+		keyConditionList: keyConditions,
 		mode:             andKeyCond,
 	}
 }
@@ -525,7 +546,7 @@ func andBuildKeyCondition(keyConditionBuilder KeyConditionBuilder, node exprNode
 	}
 	// create a string with escaped characters to substitute them with proper
 	// aliases during runtime
-	node.fmtExpr = "($c) AND ($c)"
+	node.fmtExpr = strings.Repeat("($c) AND ", len(node.children)-1) + "($c)"
 
 	return node, nil
 }

--- a/feature/dynamodb/expression/key_condition_test.go
+++ b/feature/dynamodb/expression/key_condition_test.go
@@ -338,12 +338,71 @@ func TestKeyAnd(t *testing.T) {
 			},
 		},
 		{
+			name:  "multi-attribute key and",
+			input: Key("foo").Equal(Value(5)).And(Key("bar").Equal(Value("baz"))).And(Key("qux").BeginsWith("corge")),
+			expectedNode: exprNode{
+				children: []exprNode{
+					{
+						children: []exprNode{
+							{
+								names:   []string{"foo"},
+								fmtExpr: "$n",
+							},
+							{
+								values: []types.AttributeValue{
+									&types.AttributeValueMemberN{Value: "5"},
+								},
+								fmtExpr: "$v",
+							},
+						},
+						fmtExpr: "$c = $c",
+					},
+					{
+						children: []exprNode{
+							{
+								names:   []string{"bar"},
+								fmtExpr: "$n",
+							},
+							{
+								values: []types.AttributeValue{
+									&types.AttributeValueMemberS{Value: "baz"},
+								},
+								fmtExpr: "$v",
+							},
+						},
+						fmtExpr: "$c = $c",
+					},
+					{
+						children: []exprNode{
+							{
+								names:   []string{"qux"},
+								fmtExpr: "$n",
+							},
+							{
+								values: []types.AttributeValue{
+									&types.AttributeValueMemberS{Value: "corge"},
+								},
+								fmtExpr: "$v",
+							},
+						},
+						fmtExpr: "begins_with ($c, $c)",
+					},
+				},
+				fmtExpr: "($c) AND ($c) AND ($c)",
+			},
+		},
+		{
+			name:  "multi-attribute non terminal condition is not equal",
+			input: Key("foo").Equal(Value(5)).And(Key("bar").BeginsWith("baz")).And(Key("qux").Equal(Value("corge"))),
+			err:   invalidKeyConditionFormat,
+		},
+		{
 			name:  "first condition is not equal",
 			input: Key("foo").LessThan(Value(5)).And(Key("bar").BeginsWith("baz")),
 			err:   invalidKeyConditionFormat,
 		},
 		{
-			name:  "more then one condition on key",
+			name:  "nested key conditions",
 			input: Key("foo").Equal(Value(5)).And(Key("bar").Equal(Value(1)).And(Key("baz").BeginsWith("yar"))),
 			err:   invalidKeyConditionFormat,
 		},


### PR DESCRIPTION
Problem: The key builder in the expression package only supported exactly two keys, PK + SK. Following the recently released multi-attribute key pattern for GSIs in DDB, a valid query can now support multiple key conditions (DynamoDB currently supports up to 4 partition key + 4 sort key attributes per GSI).

Solution: Update the KeyAnd portion of the expression builder to support multiple keys. Ensure that all but the last key being added are equality, and that the last key is not another KeyAnd expression. Leverage variadic function to maintain backwards compatibility with previous expression building.

Testing: make unit + unit test coverage for new behavior

Issue: None

Reference document: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/GSI.DesignPattern.MultiAttributeKeys.html

# **PLEASE READ BEFORE CONTINUING**

**DO NOT** submit pull requests that directly modify generated source files, e.g. `/service/s3/api_client.go`. Generated source files will always include an identifying header:

```
// Code generated by smithy-go-codegen DO NOT EDIT.
```

Manual changes to these files will be overwritten by code generation that occurs as part of the daily SDK release process.

**DO NOT** submit pull requests that directly modify files in the `/codegen/sdk-codegen/aws-models` folder. These are API model files, owned by each AWS service team, that are updated automatically as part of the daily SDK release process. Local changes to these files will not persist.

If you believe the contents of any of these files need to be changed, please [open an issue](https://github.com/aws/aws-sdk-go-v2/issues/new/choose).

#

If the PR addresses an existing bug or feature, please reference it here.

This PR adds in support for multi-attribute keys in the ddb expression builder. This is in support of a new DDB feature documented [here](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/GSI.DesignPattern.MultiAttributeKeys.html).

To help speed up the process and reduce the time to merge please ensure that `Allow edits by maintainers` is checked before submitting your PR. This will allow the project maintainers to make minor adjustments or improvements to the submitted PR, allow us to reduce the roundtrip time for merging your request.

# Changelog

Please **DO NOT** include a changelog entry in your pull request (you may see
what these look like in other PRs submitted directly by SDK team members). We
will take care of this for you.

