### PR TITLE
Add missing options.RequestChecksumCalculation

### DIFF
--- a/.changelog/158a3eb539734b3c938a4854e553ddcf.json
+++ b/.changelog/158a3eb539734b3c938a4854e553ddcf.json
@@ -1,0 +1,8 @@
+{
+    "id": "158a3eb5-3973-4b3c-938a-4854e553ddcf",
+    "type": "feature",
+    "description": "Add RequestChecksumCalculation config.",
+    "modules": [
+        "feature/s3/transfermanager"
+    ]
+}

--- a/feature/s3/transfermanager/api_client.go
+++ b/feature/s3/transfermanager/api_client.go
@@ -39,7 +39,7 @@ func New(s3Client S3APIClient, optFns ...func(*Options)) *Client {
 
 	resolveConcurrency(&opts)
 	resolvePartSizeBytes(&opts)
-	resolveChecksumAlgorithm(&opts)
+	resolveRequestChecksumCalculation(&opts)
 	resolveMultipartUploadThreshold(&opts)
 	resolveGetObjectType(&opts)
 	resolvePartBodyMaxRetries(&opts)

--- a/feature/s3/transfermanager/api_op_UploadObject.go
+++ b/feature/s3/transfermanager/api_op_UploadObject.go
@@ -15,9 +15,11 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/middleware"
 	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager/types"
+	internalcontext "github.com/aws/aws-sdk-go-v2/internal/context"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	smithymiddleware "github.com/aws/smithy-go/middleware"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
 )
 
 // A MultipartUploadError wraps a failed S3 multipart upload. An error returned
@@ -839,9 +841,13 @@ func (u *uploader) upload(ctx context.Context) (*UploadObjectOutput, error) {
 
 	clientOptions := []func(o *s3.Options){
 		func(o *s3.Options) {
+			o.RequestChecksumCalculation = u.options.RequestChecksumCalculation
 			o.APIOptions = append(o.APIOptions,
 				middleware.AddSDKAgentKey(middleware.FeatureMetadata, userAgentKey),
 				addFeatureUserAgent,
+				func(s *smithymiddleware.Stack) error {
+					return s.Finalize.Insert(&setS3ExpressDefaultChecksum{}, "ResolveEndpointV2", smithymiddleware.After)
+				},
 			)
 		}}
 
@@ -905,7 +911,7 @@ func (u *uploader) initSize() error {
 func (u *uploader) singleUpload(ctx context.Context, r io.Reader, sz int, cleanUp func(), clientOptions ...func(*s3.Options)) (*UploadObjectOutput, error) {
 	defer cleanUp()
 
-	params := u.in.mapSingleUploadInput(r, u.options.ChecksumAlgorithm)
+	params := u.in.mapSingleUploadInput(r, u.options.checksumAlgorithm())
 	objectSize := int64(sz)
 
 	var loc recordLocationClient
@@ -1018,7 +1024,7 @@ func (cp completedParts) Swap(i, j int) {
 // upload will perform a multipart upload using the firstBuf buffer containing
 // the first chunk of data.
 func (u *multiUploader) upload(ctx context.Context, firstBuf io.Reader, firstBuflen int, cleanup func(), clientOptions ...func(*s3.Options)) (*UploadObjectOutput, error) {
-	params := u.uploader.in.mapCreateMultipartUploadInput(u.options.ChecksumAlgorithm)
+	params := u.uploader.in.mapCreateMultipartUploadInput(u.options.checksumAlgorithm())
 
 	// We are **ignoring** the output.Location here for backwards compat.
 	//
@@ -1144,7 +1150,7 @@ func (u *multiUploader) readChunk(ctx context.Context, ch chan ulChunk, clientOp
 // send performs an UploadPart request and keeps track of the completed
 // part information.
 func (u *multiUploader) send(ctx context.Context, c ulChunk, clientOptions ...func(*s3.Options)) error {
-	params := u.in.mapUploadPartInput(c.buf, c.partNum, u.uploadID, u.options.ChecksumAlgorithm)
+	params := u.in.mapUploadPartInput(c.buf, c.partNum, u.uploadID, u.options.checksumAlgorithm())
 	resp, err := u.options.S3.UploadPart(ctx, params, clientOptions...)
 	if err != nil {
 		// progress failed() is NOT emitted here, it's emitted once at the end
@@ -1222,6 +1228,43 @@ func (u *multiUploader) complete(ctx context.Context, clientOptions ...func(*s3.
 	}
 
 	return resp
+}
+
+type setS3ExpressDefaultChecksum struct{}
+
+func (*setS3ExpressDefaultChecksum) ID() string {
+	return "setS3ExpressDefaultChecksum"
+}
+
+func (*setS3ExpressDefaultChecksum) HandleFinalize(
+	ctx context.Context, in smithymiddleware.FinalizeInput, next smithymiddleware.FinalizeHandler,
+) (
+	out smithymiddleware.FinalizeOutput, metadata smithymiddleware.Metadata, err error,
+) {
+	const checksumHeader = "x-amz-checksum-algorithm"
+
+	if internalcontext.GetS3Backend(ctx) != internalcontext.S3BackendS3Express {
+		return next.HandleFinalize(ctx, in)
+	}
+
+	// If this is CreateMultipartUpload we need to ensure the checksum
+	// algorithm header is present. Otherwise everything is driven off the
+	// context setting and we can let it flow from there.
+	if middleware.GetOperationName(ctx) == "CreateMultipartUpload" {
+		r, ok := in.Request.(*smithyhttp.Request)
+		if !ok {
+			return out, metadata, fmt.Errorf("unknown transport type %T", in.Request)
+		}
+
+		if internalcontext.GetChecksumInputAlgorithm(ctx) == "" {
+			r.Header.Set(checksumHeader, "CRC32")
+		}
+		return next.HandleFinalize(ctx, in)
+	} else if internalcontext.GetChecksumInputAlgorithm(ctx) == "" {
+		ctx = internalcontext.SetChecksumInputAlgorithm(ctx, string(s3types.ChecksumAlgorithmCrc32))
+	}
+
+	return next.HandleFinalize(ctx, in)
 }
 
 func addFeatureUserAgent(stack *smithymiddleware.Stack) error {

--- a/feature/s3/transfermanager/options.go
+++ b/feature/s3/transfermanager/options.go
@@ -3,6 +3,7 @@ package transfermanager
 import (
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager/types"
 )
 
@@ -34,6 +35,24 @@ type Options struct {
 
 	// Checksum algorithm to use for upload
 	ChecksumAlgorithm types.ChecksumAlgorithm
+
+	// RequestChecksumCalculation determines when request checksums are calculated
+	// for uploads. This setting takes precedence over the RequestChecksumCalculation
+	// configured on the underlying S3 client.
+	//
+	// There are two possible values:
+	//
+	//  1. RequestChecksumCalculationWhenSupported (default): a checksum is
+	//     calculated for every upload request, defaulting to CRC32 when the caller
+	//     does not specify a ChecksumAlgorithm.
+	//
+	//  2. RequestChecksumCalculationWhenRequired: a checksum is only calculated
+	//     when the caller specifies a ChecksumAlgorithm (on the input or these
+	//     options) or the operation otherwise requires it.
+	//
+	// Note: S3 Express One Zone (directory) buckets always require CRC32 checksums,
+	// which are applied regardless of this setting.
+	RequestChecksumCalculation aws.RequestChecksumCalculation
 
 	// The number of goroutines to spin up in parallel per call to transfer single object parts or directory objects.
 	// If this is set to zero, the DefaultUploadConcurrency value will be used.
@@ -80,10 +99,24 @@ func resolvePartSizeBytes(o *Options) {
 	}
 }
 
-func resolveChecksumAlgorithm(o *Options) {
-	if o.ChecksumAlgorithm == "" {
-		o.ChecksumAlgorithm = types.ChecksumAlgorithmCrc32
+func resolveRequestChecksumCalculation(o *Options) {
+	if o.RequestChecksumCalculation == aws.RequestChecksumCalculationUnset {
+		o.RequestChecksumCalculation = aws.RequestChecksumCalculationWhenSupported
 	}
+}
+
+func (o Options) checksumAlgorithm() types.ChecksumAlgorithm {
+	if o.ChecksumAlgorithm != "" {
+		return o.ChecksumAlgorithm
+	}
+
+	if o.RequestChecksumCalculation != aws.RequestChecksumCalculationWhenRequired {
+		return types.ChecksumAlgorithmCrc32
+	}
+
+	// Empty: the RequestChecksumCalculation client option applied to each S3 call
+	// suppresses the client's own default checksum.
+	return ""
 }
 
 func resolveMultipartUploadThreshold(o *Options) {

--- a/feature/s3/transfermanager/upload_checksum_test.go
+++ b/feature/s3/transfermanager/upload_checksum_test.go
@@ -1,0 +1,260 @@
+package transfermanager
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	s3testing "github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager/internal/testing"
+	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager/types"
+	internalcontext "github.com/aws/aws-sdk-go-v2/internal/context"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	smithymiddleware "github.com/aws/smithy-go/middleware"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
+)
+
+// checksumResolutionCases covers how the transfer manager resolves the upload
+// checksum algorithm from its RequestChecksumCalculation and ChecksumAlgorithm
+// options. Single-part and multipart uploads resolve identically.
+var checksumResolutionCases = map[string]struct {
+	requestChecksumCalculation aws.RequestChecksumCalculation
+	optionsChecksumAlgorithm   types.ChecksumAlgorithm
+	inputChecksumAlgorithm     types.ChecksumAlgorithm
+	expect                     s3types.ChecksumAlgorithm
+}{
+	"default (unset) applies CRC32": {
+		expect: s3types.ChecksumAlgorithmCrc32,
+	},
+	"WhenSupported applies CRC32": {
+		requestChecksumCalculation: aws.RequestChecksumCalculationWhenSupported,
+		expect:                     s3types.ChecksumAlgorithmCrc32,
+	},
+	"WhenRequired sets no algorithm": {
+		requestChecksumCalculation: aws.RequestChecksumCalculationWhenRequired,
+		expect:                     "",
+	},
+	"explicit input algorithm is honored": {
+		requestChecksumCalculation: aws.RequestChecksumCalculationWhenRequired,
+		inputChecksumAlgorithm:     types.ChecksumAlgorithmSha256,
+		expect:                     s3types.ChecksumAlgorithmSha256,
+	},
+	"explicit options algorithm is honored": {
+		requestChecksumCalculation: aws.RequestChecksumCalculationWhenRequired,
+		optionsChecksumAlgorithm:   types.ChecksumAlgorithmSha1,
+		expect:                     s3types.ChecksumAlgorithmSha1,
+	},
+}
+
+func TestUploadObjectSinglePartChecksum(t *testing.T) {
+	for name, c := range checksumResolutionCases {
+		t.Run(name, func(t *testing.T) {
+			client, invocations, args := s3testing.NewUploadLoggingClient(nil)
+			mgr := New(client, func(o *Options) {
+				o.RequestChecksumCalculation = c.requestChecksumCalculation
+				o.ChecksumAlgorithm = c.optionsChecksumAlgorithm
+			})
+
+			_, err := mgr.UploadObject(context.Background(), &UploadObjectInput{
+				Bucket:            aws.String("Bucket"),
+				Key:               aws.String("Key"),
+				Body:              bytes.NewReader(buf2MB),
+				ChecksumAlgorithm: c.inputChecksumAlgorithm,
+			})
+			if err != nil {
+				t.Fatalf("expect no error, got %v", err)
+			}
+
+			if diff := cmpDiff([]string{"PutObject"}, *invocations); len(diff) > 0 {
+				t.Fatal(diff)
+			}
+
+			put := (*args)[0].(*s3.PutObjectInput)
+			if e, a := c.expect, put.ChecksumAlgorithm; e != a {
+				t.Errorf("expect PutObject checksum algorithm %q, got %q", e, a)
+			}
+		})
+	}
+}
+
+func TestUploadObjectMultipartChecksum(t *testing.T) {
+	for name, c := range checksumResolutionCases {
+		t.Run(name, func(t *testing.T) {
+			client, invocations, args := s3testing.NewUploadLoggingClient(nil)
+			mgr := New(client, func(o *Options) {
+				o.RequestChecksumCalculation = c.requestChecksumCalculation
+				o.ChecksumAlgorithm = c.optionsChecksumAlgorithm
+			})
+
+			_, err := mgr.UploadObject(context.Background(), &UploadObjectInput{
+				Bucket:            aws.String("Bucket"),
+				Key:               aws.String("Key"),
+				Body:              bytes.NewReader(buf20MB),
+				ChecksumAlgorithm: c.inputChecksumAlgorithm,
+			})
+			if err != nil {
+				t.Fatalf("expect no error, got %v", err)
+			}
+
+			expectOps := []string{"CreateMultipartUpload", "UploadPart", "UploadPart", "UploadPart", "CompleteMultipartUpload"}
+			if diff := cmpDiff(expectOps, *invocations); len(diff) > 0 {
+				t.Fatal(diff)
+			}
+
+			cmu := (*args)[0].(*s3.CreateMultipartUploadInput)
+			if e, a := c.expect, cmu.ChecksumAlgorithm; e != a {
+				t.Errorf("expect CreateMultipartUpload checksum algorithm %q, got %q", e, a)
+			}
+
+			for i := 1; i <= 3; i++ {
+				part := (*args)[i].(*s3.UploadPartInput)
+				if e, a := c.expect, part.ChecksumAlgorithm; e != a {
+					t.Errorf("expect UploadPart %d checksum algorithm %q, got %q", i, e, a)
+				}
+			}
+		})
+	}
+}
+
+type cannedHTTPClient struct{ puts []http.Header }
+
+func (c *cannedHTTPClient) Do(r *http.Request) (*http.Response, error) {
+	if r.Method == http.MethodPut {
+		c.puts = append(c.puts, r.Header.Clone())
+	}
+	if r.Body != nil {
+		io.Copy(io.Discard, r.Body)
+	}
+	return &http.Response{
+		StatusCode: 200,
+		Header:     http.Header{"Etag": {`"abc"`}},
+		Body:       io.NopCloser(bytes.NewReader(nil)),
+		Request:    r,
+	}, nil
+}
+
+// TestUploadObjectChecksumClientPrecedence drives a real s3.Client through a
+// canned HTTP transport (no network) to verify that the transfer manager's
+// RequestChecksumCalculation takes precedence over the S3 client's setting on
+// the wire, as required by the s3-transfer-manager SEP.
+func TestUploadObjectChecksumClientPrecedence(t *testing.T) {
+	cases := map[string]struct {
+		tmSetting     aws.RequestChecksumCalculation
+		clientSetting aws.RequestChecksumCalculation
+		expectCRC32   bool
+	}{
+		"tm WhenRequired overrides client WhenSupported": {
+			tmSetting:     aws.RequestChecksumCalculationWhenRequired,
+			clientSetting: aws.RequestChecksumCalculationWhenSupported,
+			expectCRC32:   false,
+		},
+		"tm WhenSupported overrides client WhenRequired": {
+			tmSetting:     aws.RequestChecksumCalculationWhenSupported,
+			clientSetting: aws.RequestChecksumCalculationWhenRequired,
+			expectCRC32:   true,
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			cap := &cannedHTTPClient{}
+			cfg, err := config.LoadDefaultConfig(context.Background(),
+				config.WithRegion("us-west-2"),
+				config.WithHTTPClient(cap),
+				config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("AKID", "SECRET", "")),
+			)
+			if err != nil {
+				t.Fatalf("load config: %v", err)
+			}
+
+			s3c := s3.NewFromConfig(cfg, func(o *s3.Options) {
+				o.RequestChecksumCalculation = c.clientSetting
+			})
+			mgr := New(s3c, func(o *Options) {
+				o.RequestChecksumCalculation = c.tmSetting
+			})
+
+			if _, err := mgr.UploadObject(context.Background(), &UploadObjectInput{
+				Bucket: aws.String("bucket"),
+				Key:    aws.String("key"),
+				Body:   bytes.NewReader([]byte("hello")),
+			}); err != nil {
+				t.Fatalf("upload: %v", err)
+			}
+
+			if len(cap.puts) == 0 {
+				t.Fatal("no PUT request captured")
+			}
+			h := cap.puts[len(cap.puts)-1]
+			gotCRC32 := h.Get("X-Amz-Sdk-Checksum-Algorithm") == "CRC32"
+			if gotCRC32 != c.expectCRC32 {
+				t.Errorf("expectCRC32=%v, got x-amz-sdk-checksum-algorithm=%q trailer=%q",
+					c.expectCRC32, h.Get("X-Amz-Sdk-Checksum-Algorithm"), h.Get("X-Amz-Trailer"))
+			}
+		})
+	}
+}
+
+type captureFinalizeHandler struct {
+	ctx context.Context
+}
+
+func (h *captureFinalizeHandler) HandleFinalize(
+	ctx context.Context, _ smithymiddleware.FinalizeInput,
+) (smithymiddleware.FinalizeOutput, smithymiddleware.Metadata, error) {
+	h.ctx = ctx
+	return smithymiddleware.FinalizeOutput{}, smithymiddleware.Metadata{}, nil
+}
+
+// TestSetS3ExpressDefaultChecksum verifies that the finalize middleware still
+// forces CRC32 for S3 Express uploads even when the general checksum default is
+// suppressed, and that it is a no-op for non-Express backends.
+func TestSetS3ExpressDefaultChecksum(t *testing.T) {
+	newInput := func() smithymiddleware.FinalizeInput {
+		return smithymiddleware.FinalizeInput{Request: smithyhttp.NewStackRequest()}
+	}
+
+	t.Run("non-Express backend is a no-op", func(t *testing.T) {
+		next := &captureFinalizeHandler{}
+		_, _, err := (&setS3ExpressDefaultChecksum{}).HandleFinalize(context.Background(), newInput(), next)
+		if err != nil {
+			t.Fatalf("expect no error, got %v", err)
+		}
+
+		if a := internalcontext.GetChecksumInputAlgorithm(next.ctx); a != "" {
+			t.Errorf("expect no checksum algorithm to be set, got %q", a)
+		}
+	})
+
+	t.Run("Express backend forces CRC32 when none set", func(t *testing.T) {
+		ctx := internalcontext.SetS3Backend(context.Background(), internalcontext.S3BackendS3Express)
+		next := &captureFinalizeHandler{}
+		_, _, err := (&setS3ExpressDefaultChecksum{}).HandleFinalize(ctx, newInput(), next)
+		if err != nil {
+			t.Fatalf("expect no error, got %v", err)
+		}
+
+		if e, a := string(s3types.ChecksumAlgorithmCrc32), internalcontext.GetChecksumInputAlgorithm(next.ctx); e != a {
+			t.Errorf("expect checksum algorithm %q, got %q", e, a)
+		}
+	})
+
+	t.Run("Express backend preserves an explicit algorithm", func(t *testing.T) {
+		ctx := internalcontext.SetS3Backend(context.Background(), internalcontext.S3BackendS3Express)
+		ctx = internalcontext.SetChecksumInputAlgorithm(ctx, string(s3types.ChecksumAlgorithmSha256))
+		next := &captureFinalizeHandler{}
+		_, _, err := (&setS3ExpressDefaultChecksum{}).HandleFinalize(ctx, newInput(), next)
+		if err != nil {
+			t.Fatalf("expect no error, got %v", err)
+		}
+
+		if e, a := string(s3types.ChecksumAlgorithmSha256), internalcontext.GetChecksumInputAlgorithm(next.ctx); e != a {
+			t.Errorf("expect checksum algorithm %q preserved, got %q", e, a)
+		}
+	})
+}


### PR DESCRIPTION
adds checksum control, mirroring the SEP and old v1 behavior, but v1 actually had an oversight which ignored the setting for single-part fallback so this is more complete