### PR TITLE
Fix transfer manager v2 uploader flaky test

### DIFF
--- a/.changelog/59800600fdb343248b45b200903f7434.json
+++ b/.changelog/59800600fdb343248b45b200903f7434.json
@@ -1,0 +1,8 @@
+{
+    "id": "59800600-fdb3-4324-8b45-b200903f7434",
+    "type": "bugfix",
+    "description": "Fix flaky test from feature/s3/transfermanager upload retry",
+    "modules": [
+        "feature/s3/transfermanager"
+    ]
+}

--- a/feature/s3/transfermanager/api_op_UploadObject_test.go
+++ b/feature/s3/transfermanager/api_op_UploadObject_test.go
@@ -1318,7 +1318,7 @@ func (c *retryHTTPClient) Do(r *http.Request) (*http.Response, error) {
 	case r.Method == "PUT":
 		defer func() {
 			if err := r.Body.Close(); err != nil {
-				log.Printf("failed to close response body: %q", err)
+				log.Printf("failed to close request body: %q", err)
 			}
 		}()
 		partStr := r.URL.Query().Get("partNumber")

--- a/feature/s3/transfermanager/api_op_UploadObject_test.go
+++ b/feature/s3/transfermanager/api_op_UploadObject_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"os"
 	"reflect"
@@ -1280,7 +1281,6 @@ func TestUploadRetry(t *testing.T) {
 				UsePathStyle: true,
 				HTTPClient: &retryHTTPClient{
 					failsLeft: failsLeft,
-					t:         t,
 				},
 				Retryer: retry.NewStandard(func(o *retry.StandardOptions) {
 					o.MaxAttempts = retries + 1
@@ -1303,7 +1303,6 @@ func TestUploadRetry(t *testing.T) {
 
 type retryHTTPClient struct {
 	failsLeft []int
-	t         *testing.T
 }
 
 func (c *retryHTTPClient) Do(r *http.Request) (*http.Response, error) {
@@ -1319,7 +1318,7 @@ func (c *retryHTTPClient) Do(r *http.Request) (*http.Response, error) {
 	case r.Method == "PUT":
 		defer func() {
 			if err := r.Body.Close(); err != nil {
-				c.t.Errorf("failed to close response body: %v", err)
+				log.Printf("failed to close response body: %q", err)
 			}
 		}()
 		partStr := r.URL.Query().Get("partNumber")
@@ -1334,7 +1333,13 @@ func (c *retryHTTPClient) Do(r *http.Request) (*http.Response, error) {
 		n, _ := io.Copy(io.Discard, r.Body)
 		if c.failsLeft[part-1] == 0 {
 			if e, a := r.ContentLength, n; e != a {
-				c.t.Errorf("expect content length to be %d, got %d", e, a)
+				errBody := fmt.Sprintf("content length mismatch, expect %d, got %d", e, a)
+				return &http.Response{
+					StatusCode: 400,
+					Status:     "InternalException",
+					Header:     http.Header{"Content-Length": {strconv.Itoa(len(errBody))}},
+					Body:       io.NopCloser(strings.NewReader(errBody)),
+				}, nil
 			}
 			return &http.Response{
 				StatusCode: 200,

--- a/feature/s3/transfermanager/api_op_UploadObject_test.go
+++ b/feature/s3/transfermanager/api_op_UploadObject_test.go
@@ -1278,7 +1278,7 @@ func TestUploadRetry(t *testing.T) {
 			client := s3.New(s3.Options{
 				Region:       "us-west-2",
 				UsePathStyle: true,
-				HTTPClient: &retryHttpClient{
+				HTTPClient: &retryHTTPClient{
 					failsLeft: failsLeft,
 					t:         t,
 				},
@@ -1301,12 +1301,12 @@ func TestUploadRetry(t *testing.T) {
 	}
 }
 
-type retryHttpClient struct {
+type retryHTTPClient struct {
 	failsLeft []int
 	t         *testing.T
 }
 
-func (c *retryHttpClient) Do(r *http.Request) (*http.Response, error) {
+func (c *retryHTTPClient) Do(r *http.Request) (*http.Response, error) {
 	_, hasUploads := r.URL.Query()["uploads"]
 	switch {
 	case r.Method == "POST" && hasUploads:

--- a/feature/s3/transfermanager/api_op_UploadObject_test.go
+++ b/feature/s3/transfermanager/api_op_UploadObject_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/http/httptest"
 	"os"
 	"reflect"
 	"regexp"
@@ -1254,26 +1253,16 @@ func TestUploadRetry(t *testing.T) {
 	defer testFileCleanup(t)
 
 	cases := map[string]struct {
-		Body         io.Reader
-		PartHandlers func(testing.TB) []http.Handler
+		Body io.Reader
 	}{
 		"bytes.Buffer": {
 			Body: bytes.NewBuffer(make([]byte, defaultPartSizeBytes*part)),
-			PartHandlers: func(tb testing.TB) []http.Handler {
-				return buildFailHandlers(tb, part, retries)
-			},
 		},
 		"bytes.Reader": {
 			Body: bytes.NewReader(make([]byte, defaultPartSizeBytes*part)),
-			PartHandlers: func(tb testing.TB) []http.Handler {
-				return buildFailHandlers(tb, part, retries)
-			},
 		},
 		"os.File": {
 			Body: testFile,
-			PartHandlers: func(tb testing.TB) []http.Handler {
-				return buildFailHandlers(tb, part, retries)
-			},
 		},
 	}
 
@@ -1282,13 +1271,17 @@ func TestUploadRetry(t *testing.T) {
 			restoreSleep := sdk.TestingUseNopSleep()
 			defer restoreSleep()
 
-			mux := newMockS3UploadServer(t, c.PartHandlers(t))
-			server := httptest.NewServer(mux)
-			defer server.Close()
-
+			failsLeft := make([]int, part)
+			for i := range failsLeft {
+				failsLeft[i] = retries
+			}
 			client := s3.New(s3.Options{
-				EndpointResolverV2: s3testing.EndpointResolverV2{URL: server.URL},
-				UsePathStyle:       true,
+				Region:       "us-west-2",
+				UsePathStyle: true,
+				HTTPClient: &retryHttpClient{
+					failsLeft: failsLeft,
+					t:         t,
+				},
 				Retryer: retry.NewStandard(func(o *retry.StandardOptions) {
 					o.MaxAttempts = retries + 1
 				}),
@@ -1308,76 +1301,70 @@ func TestUploadRetry(t *testing.T) {
 	}
 }
 
-func newMockS3UploadServer(tb testing.TB, partHandler []http.Handler) *mockS3UploadServer {
-	s := &mockS3UploadServer{
-		ServeMux:     http.NewServeMux(),
-		partHandlers: partHandler,
-		tb:           tb,
-	}
-
-	s.HandleFunc("/", s.handleRequest)
-
-	return s
+type retryHttpClient struct {
+	failsLeft []int
+	t         *testing.T
 }
 
-func buildFailHandlers(tb testing.TB, part, retry int) []http.Handler {
-	handlers := make([]http.Handler, part)
-
-	for i := range part {
-		handlers[i] = &failPartHandler{
-			tb:                 tb,
-			failLeft:           retry,
-			successPartHandler: &successPartHandler{tb: tb},
-		}
-	}
-
-	return handlers
-}
-
-type mockS3UploadServer struct {
-	*http.ServeMux
-
-	tb           testing.TB
-	partHandlers []http.Handler
-}
-
-func (s mockS3UploadServer) handleRequest(w http.ResponseWriter, r *http.Request) {
-	defer func() {
-		if err := r.Body.Close(); err != nil {
-			failRequest(w, 0, "BodyCloseError", fmt.Sprintf("request body close error: %v", err))
-		}
-	}()
-
+func (c *retryHttpClient) Do(r *http.Request) (*http.Response, error) {
 	_, hasUploads := r.URL.Query()["uploads"]
-
 	switch {
 	case r.Method == "POST" && hasUploads:
-		// CreateMultipartUpload request
-		w.Header().Set("Content-Length", strconv.Itoa(len(createUploadResp)))
-		w.Write([]byte(createUploadResp))
+		// CreateMultipartUpload req
+		return &http.Response{
+			StatusCode: 200,
+			Header:     http.Header{"Content-Length": {strconv.Itoa(len(createUploadResp))}},
+			Body:       io.NopCloser(bytes.NewReader([]byte(createUploadResp))),
+		}, nil
 	case r.Method == "PUT":
+		defer func() {
+			if err := r.Body.Close(); err != nil {
+				c.t.Errorf("failed to close response body: %v", err)
+			}
+		}()
 		partStr := r.URL.Query().Get("partNumber")
 		part, err := strconv.ParseInt(partStr, 10, 64)
 		if err != nil {
-			failRequest(w, 400, "BadRequest", fmt.Sprintf("unable to parse partNumber, %q, %v", partStr, err))
-			return
+			return &http.Response{StatusCode: 400, Status: "BadRequest"}, fmt.Errorf("unable to parse partNumber, %q, %v", partStr, err)
 		}
-		if part <= 0 || part > int64(len(s.partHandlers)) {
-			failRequest(w, 400, "BadRequest", fmt.Sprintf("invalid partNumber %v", part))
-			return
+		if part <= 0 || part > int64(len(c.failsLeft)) {
+			return &http.Response{StatusCode: 400, Status: "BadRequest"}, fmt.Errorf("invalid partNumber %v", part)
 		}
-		s.partHandlers[part-1].ServeHTTP(w, r)
+
+		n, _ := io.Copy(io.Discard, r.Body)
+		if c.failsLeft[part-1] == 0 {
+			if e, a := r.ContentLength, n; e != a {
+				c.t.Errorf("expect content length to be %d, got %d", e, a)
+			}
+			return &http.Response{
+				StatusCode: 200,
+				Header:     http.Header{"Content-Length": []string{strconv.Itoa(len(uploadPartResp))}},
+				Body:       io.NopCloser(bytes.NewReader([]byte(uploadPartResp))),
+			}, nil
+		}
+		c.failsLeft[part-1]--
+		errBody := fmt.Sprintf("mock error, partNumber %s", partStr)
+		return &http.Response{
+			StatusCode: 500,
+			Status:     "InternalException",
+			Header:     http.Header{"Content-Length": {strconv.Itoa(len(errBody))}},
+			Body:       io.NopCloser(strings.NewReader(errBody)),
+		}, nil
 	case r.Method == "POST":
-		// CompleteMultipartUpload request
-		w.Header().Set("Content-Length", strconv.Itoa(len(completeUploadResp)))
-		w.Write([]byte(completeUploadResp))
+		// CompleteMultipartUpload req
+		return &http.Response{
+			StatusCode: 200,
+			Header:     http.Header{"Content-Length": []string{strconv.Itoa(len(completeUploadResp))}},
+			Body:       io.NopCloser(bytes.NewReader([]byte(completeUploadResp))),
+		}, nil
 	case r.Method == "DELETE":
-		w.Header().Set("Content-Length", strconv.Itoa(len(abortUploadResp)))
-		w.Write([]byte(abortUploadResp))
-		w.WriteHeader(200)
-	default:
-		failRequest(w, 400, "BadRequest", fmt.Sprintf("invalid request %v %v", r.Method, r.URL))
+		return &http.Response{
+			StatusCode: 200,
+			Header:     http.Header{"Content-Length": []string{strconv.Itoa(len(abortUploadResp))}},
+			Body:       io.NopCloser(bytes.NewReader([]byte(abortUploadResp))),
+		}, nil
 	}
+	return &http.Response{StatusCode: 400, Status: "BadRequest"}, fmt.Errorf("invalid request %v %v", r.Method, r.URL)
 }
 
 func createTempFile(t *testing.T, size int64) (*os.File, func(*testing.T), error) {
@@ -1402,70 +1389,6 @@ func createTempFile(t *testing.T, size int64) (*os.File, func(*testing.T), error
 		nil
 }
 
-type failPartHandler struct {
-	tb                 testing.TB
-	failLeft           int
-	successPartHandler http.Handler
-}
-
-func (h *failPartHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	defer func() {
-		if err := r.Body.Close(); err != nil {
-			failRequest(w, 0, "BodyCloseError", fmt.Sprintf("request body close error: %v", err))
-		}
-	}()
-
-	if h.failLeft == 0 && h.successPartHandler != nil {
-		h.successPartHandler.ServeHTTP(w, r)
-		return
-	}
-
-	io.Copy(io.Discard, r.Body)
-	failRequest(w, 500, "InternalException", fmt.Sprintf("mock error, partNumber %v", r.URL.Query().Get("partNumber")))
-	h.failLeft--
-}
-
-func failRequest(w http.ResponseWriter, status int, code, msg string) {
-	msg = fmt.Sprintf(baseRequestErrorResp, code, msg)
-	w.Header().Set("Content-Length", strconv.Itoa(len(msg)))
-	w.WriteHeader(status)
-	w.Write([]byte(msg))
-}
-
-type successPartHandler struct {
-	tb testing.TB
-}
-
-func (h *successPartHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	defer func() {
-		if err := r.Body.Close(); err != nil {
-			failRequest(w, 0, "BodyCloseError", fmt.Sprintf("request body close error: %v", err))
-		}
-	}()
-
-	n, err := io.Copy(io.Discard, r.Body)
-	if err != nil {
-		failRequest(w, 400, "BadRequest", fmt.Sprintf("failed to read body, %v", err))
-		return
-	}
-	contentLength := r.Header.Get("Content-Length")
-	expectLength, err := strconv.ParseInt(contentLength, 10, 64)
-	if err != nil {
-		h.tb.Logf("expect content-length, got %q, %v", contentLength, err)
-		failRequest(w, 400, "BadRequest", fmt.Sprintf("unable to get content-length %v", err))
-		return
-	}
-
-	if e, a := expectLength, n; e != a {
-		h.tb.Logf("expect content-length to be %v, got %v", e, a)
-		failRequest(w, 400, "BadRequest", fmt.Sprintf("content-length and body do not match, %v, %v", e, a))
-		return
-	}
-
-	w.Header().Set("Content-Length", strconv.Itoa(len(uploadPartResp)))
-	w.Write([]byte(uploadPartResp))
-}
-
 const createUploadResp = `<CreateMultipartUploadResponse>
   <Bucket>bucket</Bucket>
   <Key>key</Key>
@@ -1475,12 +1398,6 @@ const createUploadResp = `<CreateMultipartUploadResponse>
 const uploadPartResp = `<UploadPartResponse>
   <ETag>key</ETag>
 </UploadPartResponse>`
-const baseRequestErrorResp = `<batchItemError>
-  <Code>%s</Code>
-  <Message>%s</Message>
-  <RequestId>request-id</RequestId>
-  <HostId>host-id</HostId>
-</batchItemError>`
 
 const completeUploadResp = `<CompleteMultipartUploadResponse>
   <Bucket>bucket</Bucket>


### PR DESCRIPTION
 Existing transfer manager v2 upload retry test uses a mock http server locally to upload a 24MB object, where most of time is consumed on transport/socket layer. Under a concurrent multipart upload case, 11(attemps) * 8MB(part size) * 3(parts) = 264MB are copied through the loopback TCP stack (write/read syscalls, netpoll, bufio, HTTP framing), plus server-side io.Copy of every body, connection churn, and the Expect: 100-continue handshakes. All those wire workflow causes overloads of CI's poor CPU and leads to flaky timeout. This PR replaces the mock server with just a mock http client so no wire roundtrip will be counted

Local starving test is shown here though it may not 100% mock CI cpu core config:
go to `feature/s3/transfermanager` package then run
```
go test -race -c -o /tmp/tm.test ./ && \
  for i in $(seq $(sysctl -n hw.ncpu)); do yes >/dev/null & done; HOGS=$(jobs -p); \
  GOMAXPROCS=2 /tmp/tm.test -test.run '^TestUploadRetry$' -test.cpu=2 -test.count=20 -test.timeout=30s; \
  echo "exit=$?"; kill $HOGS 2>/dev/null
```
It uses max process 2 and different hogs to mock CI cpu's workload, `exit=0` should be output showing the low cpu core like CI still passed the unit test under timeout

