### PR TITLE
Add SSE-C, versionId and other fields to the first HeadObject call on Transfer Manager

### DIFF
--- a/.changelog/4f7102de73b344ec84fa86aac7f4d2fc.json
+++ b/.changelog/4f7102de73b344ec84fa86aac7f4d2fc.json
@@ -1,0 +1,8 @@
+{
+    "id": "4f7102de-73b3-44ec-84fa-86aac7f4d2fc",
+    "type": "bugfix",
+    "description": "Forward SSE-C, VersionId, RequestPayer and other fields to HeadObject call when using transfer manager",
+    "modules": [
+        "feature/s3/transfermanager"
+    ]
+}

--- a/feature/s3/transfermanager/api_op_GetObject.go
+++ b/feature/s3/transfermanager/api_op_GetObject.go
@@ -630,9 +630,12 @@ func (g *getter) get(ctx context.Context) (out *GetObjectOutput, err error) {
 	if g.options.GetObjectType == types.GetObjectParts {
 		// must know the part size before creating stream reader
 		out, err := g.options.S3.HeadObject(ctx, &s3.HeadObjectInput{
-			Bucket:     g.in.Bucket,
-			Key:        g.in.Key,
-			PartNumber: aws.Int32(1),
+			Bucket:               g.in.Bucket,
+			Key:                  g.in.Key,
+			PartNumber:           aws.Int32(1),
+			SSECustomerAlgorithm: g.in.SSECustomerAlgorithm,
+			SSECustomerKey:       g.in.SSECustomerKey,
+			SSECustomerKeyMD5:    g.in.SSECustomerKeyMD5,
 		}, clientOptions...)
 		if err != nil {
 			return nil, err
@@ -652,8 +655,11 @@ func (g *getter) get(ctx context.Context) (out *GetObjectOutput, err error) {
 		r.partsCount = partsCount
 	} else {
 		out, err := g.options.S3.HeadObject(ctx, &s3.HeadObjectInput{
-			Bucket: g.in.Bucket,
-			Key:    g.in.Key,
+			Bucket:               g.in.Bucket,
+			Key:                  g.in.Key,
+			SSECustomerAlgorithm: g.in.SSECustomerAlgorithm,
+			SSECustomerKey:       g.in.SSECustomerKey,
+			SSECustomerKeyMD5:    g.in.SSECustomerKeyMD5,
 		}, clientOptions...)
 		if err != nil {
 			return nil, err

--- a/feature/s3/transfermanager/api_op_GetObject.go
+++ b/feature/s3/transfermanager/api_op_GetObject.go
@@ -636,6 +636,11 @@ func (g *getter) get(ctx context.Context) (out *GetObjectOutput, err error) {
 			SSECustomerAlgorithm: g.in.SSECustomerAlgorithm,
 			SSECustomerKey:       g.in.SSECustomerKey,
 			SSECustomerKeyMD5:    g.in.SSECustomerKeyMD5,
+			ExpectedBucketOwner:  g.in.ExpectedBucketOwner,
+			RequestPayer:         s3types.RequestPayer(g.in.RequestPayer),
+			VersionId:            g.in.VersionID,
+			IfModifiedSince:      g.in.IfModifiedSince,
+			IfUnmodifiedSince:    g.in.IfUnmodifiedSince,
 		}, clientOptions...)
 		if err != nil {
 			return nil, err
@@ -660,6 +665,11 @@ func (g *getter) get(ctx context.Context) (out *GetObjectOutput, err error) {
 			SSECustomerAlgorithm: g.in.SSECustomerAlgorithm,
 			SSECustomerKey:       g.in.SSECustomerKey,
 			SSECustomerKeyMD5:    g.in.SSECustomerKeyMD5,
+			ExpectedBucketOwner:  g.in.ExpectedBucketOwner,
+			RequestPayer:         s3types.RequestPayer(g.in.RequestPayer),
+			VersionId:            g.in.VersionID,
+			IfModifiedSince:      g.in.IfModifiedSince,
+			IfUnmodifiedSince:    g.in.IfUnmodifiedSince,
 		}, clientOptions...)
 		if err != nil {
 			return nil, err

--- a/feature/s3/transfermanager/getobject_test.go
+++ b/feature/s3/transfermanager/getobject_test.go
@@ -517,15 +517,15 @@ func TestGetObjectWithContextCanceled(t *testing.T) {
 	}
 }
 
-func TestGetObject_SSECParamsForwardedToHeadObject(t *testing.T) {
+func TestGetObject_HeadObjectForwardsRequiredFields(t *testing.T) {
 	cases := map[string]struct {
 		getObjectType types.GetObjectType
 		partsCount    int32
 	}{
-		"GetObjectRanges forwards SSE-C to HeadObject": {
+		"GetObjectRanges": {
 			getObjectType: types.GetObjectRanges,
 		},
-		"GetObjectParts forwards SSE-C to HeadObject": {
+		"GetObjectParts": {
 			getObjectType: types.GetObjectParts,
 			partsCount:    3,
 		},
@@ -549,6 +549,8 @@ func TestGetObject_SSECParamsForwardedToHeadObject(t *testing.T) {
 			// 32 bytes encoded as base64 — the value SSE-C requires
 			sseKey := base64.StdEncoding.EncodeToString([]byte("01234567890123456789012345678901"))
 			sseKeyMD5 := base64.StdEncoding.EncodeToString([]byte("md5-of-the-key!!"))
+			modifiedSince := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+			unmodifiedSince := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
 
 			input := &GetObjectInput{
 				Bucket:               aws.String("bucket"),
@@ -556,6 +558,11 @@ func TestGetObject_SSECParamsForwardedToHeadObject(t *testing.T) {
 				SSECustomerAlgorithm: aws.String("AES256"),
 				SSECustomerKey:       aws.String(sseKey),
 				SSECustomerKeyMD5:    aws.String(sseKeyMD5),
+				ExpectedBucketOwner:  aws.String("123456789012"),
+				RequestPayer:         "requester",
+				VersionID:            aws.String("version-abc"),
+				IfModifiedSince:      &modifiedSince,
+				IfUnmodifiedSince:    &unmodifiedSince,
 			}
 
 			out, err := mgr.GetObject(context.Background(), input)
@@ -571,6 +578,7 @@ func TestGetObject_SSECParamsForwardedToHeadObject(t *testing.T) {
 
 			headInput := s3Client.HeadObjectInputs[0]
 
+			// SSE-C fields
 			if e, a := "AES256", aws.ToString(headInput.SSECustomerAlgorithm); e != a {
 				t.Errorf("HeadObject SSECustomerAlgorithm: expected %q, got %q", e, a)
 			}
@@ -579,6 +587,29 @@ func TestGetObject_SSECParamsForwardedToHeadObject(t *testing.T) {
 			}
 			if e, a := sseKeyMD5, aws.ToString(headInput.SSECustomerKeyMD5); e != a {
 				t.Errorf("HeadObject SSECustomerKeyMD5: expected %q, got %q", e, a)
+			}
+
+			// Requester-pays
+			if e, a := s3types.RequestPayerRequester, headInput.RequestPayer; e != a {
+				t.Errorf("HeadObject RequestPayer: expected %q, got %q", e, a)
+			}
+
+			// Account safety
+			if e, a := "123456789012", aws.ToString(headInput.ExpectedBucketOwner); e != a {
+				t.Errorf("HeadObject ExpectedBucketOwner: expected %q, got %q", e, a)
+			}
+
+			// Version
+			if e, a := "version-abc", aws.ToString(headInput.VersionId); e != a {
+				t.Errorf("HeadObject VersionId: expected %q, got %q", e, a)
+			}
+
+			// Conditional request fields
+			if headInput.IfModifiedSince == nil || !headInput.IfModifiedSince.Equal(modifiedSince) {
+				t.Errorf("HeadObject IfModifiedSince: expected %v, got %v", modifiedSince, headInput.IfModifiedSince)
+			}
+			if headInput.IfUnmodifiedSince == nil || !headInput.IfUnmodifiedSince.Equal(unmodifiedSince) {
+				t.Errorf("HeadObject IfUnmodifiedSince: expected %v, got %v", unmodifiedSince, headInput.IfUnmodifiedSince)
 			}
 		})
 	}

--- a/feature/s3/transfermanager/getobject_test.go
+++ b/feature/s3/transfermanager/getobject_test.go
@@ -3,6 +3,7 @@ package transfermanager
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"reflect"
@@ -511,6 +512,73 @@ func TestGetObjectWithContextCanceled(t *testing.T) {
 			}
 			if e, a := "canceled", err.Error(); !strings.Contains(a, e) {
 				t.Errorf("expected error message to contain %q, but did not %q", e, a)
+			}
+		})
+	}
+}
+
+func TestGetObject_SSECParamsForwardedToHeadObject(t *testing.T) {
+	cases := map[string]struct {
+		getObjectType types.GetObjectType
+		partsCount    int32
+	}{
+		"GetObjectRanges forwards SSE-C to HeadObject": {
+			getObjectType: types.GetObjectRanges,
+		},
+		"GetObjectParts forwards SSE-C to HeadObject": {
+			getObjectType: types.GetObjectParts,
+			partsCount:    3,
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			s3Client, _, _, _, _, _ := s3testing.NewDownloadClient()
+			s3Client.Data = buf2MB
+			s3Client.GetObjectFn = s3testing.RangeGetObjectFn
+			s3Client.PartsCount = c.partsCount
+
+			if c.getObjectType == types.GetObjectParts {
+				s3Client.GetObjectFn = s3testing.PartGetObjectFn
+			}
+
+			mgr := New(s3Client, func(o *Options) {
+				o.GetObjectType = c.getObjectType
+			})
+
+			// 32 bytes encoded as base64 — the value SSE-C requires
+			sseKey := base64.StdEncoding.EncodeToString([]byte("01234567890123456789012345678901"))
+			sseKeyMD5 := base64.StdEncoding.EncodeToString([]byte("md5-of-the-key!!"))
+
+			input := &GetObjectInput{
+				Bucket:               aws.String("bucket"),
+				Key:                  aws.String("key"),
+				SSECustomerAlgorithm: aws.String("AES256"),
+				SSECustomerKey:       aws.String(sseKey),
+				SSECustomerKeyMD5:    aws.String(sseKeyMD5),
+			}
+
+			out, err := mgr.GetObject(context.Background(), input)
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			// drain the body
+			io.Copy(io.Discard, out.Body)
+
+			if len(s3Client.HeadObjectInputs) == 0 {
+				t.Fatal("expected HeadObject to be called, but it was not")
+			}
+
+			headInput := s3Client.HeadObjectInputs[0]
+
+			if e, a := "AES256", aws.ToString(headInput.SSECustomerAlgorithm); e != a {
+				t.Errorf("HeadObject SSECustomerAlgorithm: expected %q, got %q", e, a)
+			}
+			if e, a := sseKey, aws.ToString(headInput.SSECustomerKey); e != a {
+				t.Errorf("HeadObject SSECustomerKey: expected %q, got %q", e, a)
+			}
+			if e, a := sseKeyMD5, aws.ToString(headInput.SSECustomerKeyMD5); e != a {
+				t.Errorf("HeadObject SSECustomerKeyMD5: expected %q, got %q", e, a)
 			}
 		})
 	}

--- a/feature/s3/transfermanager/internal/testing/client.go
+++ b/feature/s3/transfermanager/internal/testing/client.go
@@ -40,6 +40,8 @@ type TransferManagerLoggingClient struct {
 
 	GetObjectInvocations int
 
+	HeadObjectInputs []*s3.HeadObjectInput
+
 	RetrievedRanges []string
 	RetrievedParts  []int32
 	Versions        []string
@@ -246,6 +248,8 @@ func (c *TransferManagerLoggingClient) GetObject(ctx context.Context, params *s3
 func (c *TransferManagerLoggingClient) HeadObject(ctx context.Context, params *s3.HeadObjectInput, optFns ...func(*s3.Options)) (*s3.HeadObjectOutput, error) {
 	c.m.Lock()
 	defer c.m.Unlock()
+
+	c.HeadObjectInputs = append(c.HeadObjectInputs, params)
 
 	return &s3.HeadObjectOutput{
 		PartsCount:        aws.Int32(c.PartsCount),


### PR DESCRIPTION
Fixes #3490

## Description

Fix `transfermanager.GetObject()` failing for SSE-C encrypted objects and other scenarios where request-level fields are required on every S3 API call.

### Problem

The transfer manager calls `HeadObject` internally to discover object size before issuing parallel ranged/part GETs. These `HeadObject` calls only passed `Bucket` and `Key` — they didn't forward fields from the user's input that S3 requires on every request to the object.

This caused failures for:
- **SSE-C encrypted objects** — S3 requires the encryption key on every request including HeadObject, returning 400 without it (reported at #3490)

Additionally, I took a look at the other fields we added when calling `GetObject` and added the following parameters

- **Requester-pays buckets** — S3 requires the `x-amz-request-payer` header, returning 403 without it
- **Version-specific downloads** — HeadObject could check a different version than what gets downloaded
- **Conditional requests** — `IfModifiedSince`/`IfUnmodifiedSince` weren't applied consistently
- **Cross-account safety** — `ExpectedBucketOwner` wasn't enforced on the HeadObject call

The ranged/part GET calls themselves were fine — `mapGetObjectInput()` already forwards all fields correctly. It was only the manually-constructed `HeadObject` calls that were missing them.

### Fix

Add the missing fields to both `HeadObjectInput` structs in `getter.get()` (the `GetObjectParts` path and the `GetObjectRanges` path):

- `SSECustomerAlgorithm`, `SSECustomerKey`, `SSECustomerKeyMD5`
- `RequestPayer`
- `ExpectedBucketOwner`
- `VersionId`
- `IfModifiedSince`, `IfUnmodifiedSince`

### Testing
Full repro at https://gist.github.com/Madrigal/27ccd834d4623bf5179f789199a90807
* Created a bucket with SSE-C configuration
* Uploaded a large object, verified it fails
* Apply the fix in this PR
* Ensure it suceeds