### PR TITLE
Expand checks for S3 200 errors to more operations (wave 1)

### DIFF
--- a/.changelog/5b72ece8d1944b2ba99ad90ad3690b46.json
+++ b/.changelog/5b72ece8d1944b2ba99ad90ad3690b46.json
@@ -1,0 +1,8 @@
+{
+    "id": "5b72ece8-d194-4b2b-a99a-d90ad3690b46",
+    "type": "bugfix",
+    "description": "Expand S3 operations that check for an error inside an HTTP 200 response",
+    "modules": [
+        "service/s3"
+    ]
+}

--- a/codegen/smithy-aws-go-codegen/src/main/java/software/amazon/smithy/aws/go/codegen/customization/service/s3/S3ErrorWith200Status.java
+++ b/codegen/smithy-aws-go-codegen/src/main/java/software/amazon/smithy/aws/go/codegen/customization/service/s3/S3ErrorWith200Status.java
@@ -15,8 +15,10 @@
 
 package software.amazon.smithy.aws.go.codegen.customization.service.s3;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import software.amazon.smithy.aws.go.codegen.customization.AwsCustomGoDependency;
 import software.amazon.smithy.go.codegen.SymbolUtils;
@@ -24,10 +26,8 @@ import software.amazon.smithy.go.codegen.integration.GoIntegration;
 import software.amazon.smithy.go.codegen.integration.MiddlewareRegistrar;
 import software.amazon.smithy.go.codegen.integration.RuntimeClientPlugin;
 import software.amazon.smithy.model.Model;
-import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
-import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.traits.HttpPayloadTrait;
@@ -41,9 +41,153 @@ import software.amazon.smithy.model.traits.StreamingTrait;
  * streaming binary payload or event-stream. In Smithy terms, this means all
  * S3 operations whose output does not contain a member with @httpPayload
  * targeting a @streaming blob, @streaming union, or string.
+ *
+ * Coverage is being rolled out in waves gated by call volume. Once all waves
+ * have soaked, remove the wave sets and the isInEnabledWave check — the
+ * model-driven logic in supports200Error is the correct final behavior.
  */
 public class S3ErrorWith200Status implements GoIntegration {
-    private static String ADD_ERROR_HANDLER_INTERNAL = "HandleResponseErrorWith200Status";
+    private static final String ADD_ERROR_HANDLER_INTERNAL = "HandleResponseErrorWith200Status";
+
+    // Already covered on main — always enabled.
+    private static final Set<String> ORIGINAL_OPERATIONS = Set.of(
+            "CopyObject", "UploadPartCopy", "CompleteMultipartUpload"
+    );
+
+    // Wave 1: < 1B req/week. Very low risk.
+    private static final Set<String> WAVE_1_OPERATIONS = Set.of(
+            "AbortMultipartUpload",
+            "CreateBucketMetadataConfiguration",
+            "CreateBucketMetadataTableConfiguration",
+            "CreateSession",
+            "DeleteBucket",
+            "DeleteBucketAnalyticsConfiguration",
+            "DeleteBucketCors",
+            "DeleteBucketEncryption",
+            "DeleteBucketIntelligentTieringConfiguration",
+            "DeleteBucketInventoryConfiguration",
+            "DeleteBucketLifecycle",
+            "DeleteBucketMetadataConfiguration",
+            "DeleteBucketMetadataTableConfiguration",
+            "DeleteBucketMetricsConfiguration",
+            "DeleteBucketOwnershipControls",
+            "DeleteBucketPolicy",
+            "DeleteBucketReplication",
+            "DeleteBucketTagging",
+            "DeleteBucketWebsite",
+            "DeleteObjectAnnotation",
+            "DeleteObjectTagging",
+            "DeletePublicAccessBlock",
+            "GetBucketAbac",
+            "GetBucketAnalyticsConfiguration",
+            "GetBucketIntelligentTieringConfiguration",
+            "GetBucketInventoryConfiguration",
+            "GetBucketMetadataConfiguration",
+            "GetBucketMetadataTableConfiguration",
+            "GetBucketMetricsConfiguration",
+            "GetBucketTagging",
+            "GetObjectAcl",
+            "GetObjectAttributes",
+            "GetObjectLegalHold",
+            "GetObjectRetention",
+            "GetPublicAccessBlock",
+            "ListBucketAnalyticsConfigurations",
+            "ListBucketIntelligentTieringConfigurations",
+            "ListBucketInventoryConfigurations",
+            "ListBucketMetricsConfigurations",
+            "ListMultipartUploads",
+            "ListObjectAnnotations",
+            "ListParts",
+            "PutBucketAbac",
+            "PutBucketAccelerateConfiguration",
+            "PutBucketCors",
+            "PutBucketIntelligentTieringConfiguration",
+            "PutBucketInventoryConfiguration",
+            "PutBucketLifecycleConfiguration",
+            "PutBucketLogging",
+            "PutBucketMetricsConfiguration",
+            "PutBucketNotificationConfiguration",
+            "PutBucketOwnershipControls",
+            "PutBucketReplication",
+            "PutBucketRequestPayment",
+            "PutBucketTagging",
+            "PutBucketVersioning",
+            "PutBucketWebsite",
+            "PutObjectAnnotation",
+            "PutObjectLegalHold",
+            "PutObjectLockConfiguration",
+            "PutPublicAccessBlock",
+            "RenameObject",
+            "RestoreObject",
+            "UpdateBucketMetadataAnnotationTableConfiguration",
+            "UpdateBucketMetadataInventoryTableConfiguration",
+            "UpdateBucketMetadataJournalTableConfiguration",
+            "UpdateObjectEncryption",
+            "WriteGetObjectResponse"
+    );
+
+    // Wave 2: 600M–5B req/week. Low-medium risk.
+    private static final Set<String> WAVE_2_OPERATIONS = Set.of(
+            "GetBucketAccelerateConfiguration",
+            "GetBucketCors",
+            "GetBucketLifecycleConfiguration",
+            "GetBucketLogging",
+            "GetBucketNotificationConfiguration",
+            "GetBucketOwnershipControls",
+            "GetBucketPolicyStatus",
+            "GetBucketReplication",
+            "GetBucketRequestPayment",
+            "GetBucketVersioning",
+            "GetBucketWebsite",
+            "GetObjectLockConfiguration",
+            "GetPublicAccessBlock",
+            "ListBuckets",
+            "ListDirectoryBuckets",
+            "PutBucketAcl",
+            "PutBucketEncryption",
+            "PutBucketPolicy"
+    );
+
+    // Wave 3: 5B–20B req/week. Medium risk.
+    private static final Set<String> WAVE_3_OPERATIONS = Set.of(
+            "CreateMultipartUpload",
+            "DeleteObjects",
+            "GetBucketAcl",
+            "GetBucketEncryption",
+            "GetBucketLocation",
+            "GetObjectTagging",
+            "HeadBucket",
+            "ListObjectVersions",
+            "PutObjectRetention",
+            "PutObjectTagging"
+    );
+
+    // Wave 4: 50B+ req/week. Medium-high risk (volume).
+    private static final Set<String> WAVE_4_OPERATIONS = Set.of(
+            "CreateBucket",
+            "DeleteObject",
+            "HeadObject",
+            "ListObjects",
+            "ListObjectsV2",
+            "PutObject",
+            "UploadPart"
+    );
+
+    /**
+     * Combined set of all currently enabled operations. To enable a wave,
+     * add it to this set. To finish rollout, delete all wave sets and the
+     * isInEnabledWave check entirely.
+     */
+    private static final Set<String> ENABLED_OPERATIONS = buildEnabledOperations();
+
+    private static Set<String> buildEnabledOperations() {
+        Set<String> enabled = new HashSet<>(ORIGINAL_OPERATIONS);
+        enabled.addAll(WAVE_1_OPERATIONS);
+        // enabled.addAll(WAVE_2_OPERATIONS);
+        // enabled.addAll(WAVE_3_OPERATIONS);
+        // enabled.addAll(WAVE_4_OPERATIONS);
+        return Set.copyOf(enabled);
+    }
 
     @Override
     public byte getOrder() {
@@ -68,29 +212,33 @@ public class S3ErrorWith200Status implements GoIntegration {
     /**
      * Returns true if the operation supports error response with 200 ok status code.
      *
-     * Per internal specification, this applies to all S3 operations whose output
-     * does NOT contain an @httpPayload member targeting either:
-     *   - a shape with the @streaming trait (blob or event stream)
-     *   - a string shape
+     * Uses a two-layer check:
+     * 1. Model-driven: excludes operations with @httpPayload targeting @streaming or string.
+     * 2. Wave gate: only enables operations that are in a currently-active wave.
+     *
+     * Once all waves are shipped and baked, remove the wave gate (step 2) and
+     * the model-driven logic alone becomes the final behavior.
      */
     private static boolean supports200Error(Model model, ServiceShape service, OperationShape operation) {
         if (!isS3Service(model, service)) {
             return false;
         }
 
+        // Model-driven exclusion: this is the correct final logic.
         Optional<ShapeId> output = operation.getOutput();
-        if (!output.isPresent()) {
-            // No output structure means a structured (empty) XML response, apply the check.
-            return true;
+        if (output.isPresent()) {
+            StructureShape outputShape = model.expectShape(output.get(), StructureShape.class);
+            boolean excluded = outputShape.getAllMembers().values().stream()
+                    .filter(member -> member.hasTrait(HttpPayloadTrait.class))
+                    .map(member -> model.expectShape(member.getTarget()))
+                    .anyMatch(target -> target.hasTrait(StreamingTrait.class) || target.isStringShape());
+            if (excluded) {
+                return false;
+            }
         }
 
-        StructureShape outputShape = model.expectShape(output.get(), StructureShape.class);
-
-        // Exclude if any @httpPayload member targets a @streaming shape or a string.
-        return outputShape.getAllMembers().values().stream()
-                .filter(member -> member.hasTrait(HttpPayloadTrait.class))
-                .map(member -> model.expectShape(member.getTarget()))
-                .noneMatch(target -> target.hasTrait(StreamingTrait.class) || target.isStringShape());
+        // Wave gate: remove this check once all waves are shipped and baked.
+        return ENABLED_OPERATIONS.contains(operation.getId().getName(service));
     }
 
     // returns true if service is s3

--- a/codegen/smithy-aws-go-codegen/src/main/java/software/amazon/smithy/aws/go/codegen/customization/service/s3/S3ErrorWith200Status.java
+++ b/codegen/smithy-aws-go-codegen/src/main/java/software/amazon/smithy/aws/go/codegen/customization/service/s3/S3ErrorWith200Status.java
@@ -1,7 +1,22 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package software.amazon.smithy.aws.go.codegen.customization.service.s3;
 
 import java.util.List;
-import java.util.Set;
+import java.util.Optional;
 
 import software.amazon.smithy.aws.go.codegen.customization.AwsCustomGoDependency;
 import software.amazon.smithy.go.codegen.SymbolUtils;
@@ -9,20 +24,26 @@ import software.amazon.smithy.go.codegen.integration.GoIntegration;
 import software.amazon.smithy.go.codegen.integration.MiddlewareRegistrar;
 import software.amazon.smithy.go.codegen.integration.RuntimeClientPlugin;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
-import software.amazon.smithy.utils.ListUtils;
-import software.amazon.smithy.utils.SetUtils;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.traits.HttpPayloadTrait;
+import software.amazon.smithy.model.traits.StreamingTrait;
 
 /**
  * Adds middleware to handle S3 response errors with 200 ok status code.
+ *
+ * Per internal specification, this customization MUST be applied to all S3
+ * operations with a structured XML response. The response MUST NOT have a
+ * streaming binary payload or event-stream. In Smithy terms, this means all
+ * S3 operations whose output does not contain a member with @httpPayload
+ * targeting a @streaming blob, @streaming union, or string.
  */
 public class S3ErrorWith200Status implements GoIntegration {
     private static String ADD_ERROR_HANDLER_INTERNAL = "HandleResponseErrorWith200Status";
-
-    // list of operations for which this customization is valid.
-    private static Set<String> customizedOperations = SetUtils.of(
-            "CopyObject", "UploadPartCopy", "CompleteMultipartUpload");
 
     @Override
     public byte getOrder() {
@@ -33,7 +54,7 @@ public class S3ErrorWith200Status implements GoIntegration {
 
     @Override
     public List<RuntimeClientPlugin> getClientPlugins() {
-        return ListUtils.of(
+        return List.of(
                 RuntimeClientPlugin.builder()
                         .operationPredicate(S3ErrorWith200Status::supports200Error)
                         .registerMiddleware(MiddlewareRegistrar.builder()
@@ -44,13 +65,32 @@ public class S3ErrorWith200Status implements GoIntegration {
         );
     }
 
-    // returns true if the operation supports error response with 200 ok status code
-    private static boolean supports200Error(Model model, ServiceShape service, OperationShape operation){
+    /**
+     * Returns true if the operation supports error response with 200 ok status code.
+     *
+     * Per internal specification, this applies to all S3 operations whose output
+     * does NOT contain an @httpPayload member targeting either:
+     *   - a shape with the @streaming trait (blob or event stream)
+     *   - a string shape
+     */
+    private static boolean supports200Error(Model model, ServiceShape service, OperationShape operation) {
         if (!isS3Service(model, service)) {
             return false;
         }
 
-       return customizedOperations.contains(operation.getId().getName(service));
+        Optional<ShapeId> output = operation.getOutput();
+        if (!output.isPresent()) {
+            // No output structure means a structured (empty) XML response, apply the check.
+            return true;
+        }
+
+        StructureShape outputShape = model.expectShape(output.get(), StructureShape.class);
+
+        // Exclude if any @httpPayload member targets a @streaming shape or a string.
+        return outputShape.getAllMembers().values().stream()
+                .filter(member -> member.hasTrait(HttpPayloadTrait.class))
+                .map(member -> model.expectShape(member.getTarget()))
+                .noneMatch(target -> target.hasTrait(StreamingTrait.class) || target.isStringShape());
     }
 
     // returns true if service is s3

--- a/service/s3/api_op_AbortMultipartUpload.go
+++ b/service/s3/api_op_AbortMultipartUpload.go
@@ -262,6 +262,9 @@ func (c *Client) addOperationAbortMultipartUploadMiddlewares(stack *middleware.S
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_CreateBucket.go
+++ b/service/s3/api_op_CreateBucket.go
@@ -364,6 +364,9 @@ func (c *Client) addOperationCreateBucketMiddlewares(stack *middleware.Stack, op
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_CreateBucket.go
+++ b/service/s3/api_op_CreateBucket.go
@@ -364,9 +364,6 @@ func (c *Client) addOperationCreateBucketMiddlewares(stack *middleware.Stack, op
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
-	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
-		return err
-	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_CreateBucketMetadataConfiguration.go
+++ b/service/s3/api_op_CreateBucketMetadataConfiguration.go
@@ -205,6 +205,9 @@ func (c *Client) addOperationCreateBucketMetadataConfigurationMiddlewares(stack 
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_CreateBucketMetadataTableConfiguration.go
+++ b/service/s3/api_op_CreateBucketMetadataTableConfiguration.go
@@ -183,6 +183,9 @@ func (c *Client) addOperationCreateBucketMetadataTableConfigurationMiddlewares(s
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_CreateMultipartUpload.go
+++ b/service/s3/api_op_CreateMultipartUpload.go
@@ -920,9 +920,6 @@ func (c *Client) addOperationCreateMultipartUploadMiddlewares(stack *middleware.
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
-	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
-		return err
-	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_CreateMultipartUpload.go
+++ b/service/s3/api_op_CreateMultipartUpload.go
@@ -920,6 +920,9 @@ func (c *Client) addOperationCreateMultipartUploadMiddlewares(stack *middleware.
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_CreateSession.go
+++ b/service/s3/api_op_CreateSession.go
@@ -349,6 +349,9 @@ func (c *Client) addOperationCreateSessionMiddlewares(stack *middleware.Stack, o
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_DeleteBucket.go
+++ b/service/s3/api_op_DeleteBucket.go
@@ -175,6 +175,9 @@ func (c *Client) addOperationDeleteBucketMiddlewares(stack *middleware.Stack, op
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_DeleteBucketAnalyticsConfiguration.go
+++ b/service/s3/api_op_DeleteBucketAnalyticsConfiguration.go
@@ -150,6 +150,9 @@ func (c *Client) addOperationDeleteBucketAnalyticsConfigurationMiddlewares(stack
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_DeleteBucketCors.go
+++ b/service/s3/api_op_DeleteBucketCors.go
@@ -138,6 +138,9 @@ func (c *Client) addOperationDeleteBucketCorsMiddlewares(stack *middleware.Stack
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_DeleteBucketEncryption.go
+++ b/service/s3/api_op_DeleteBucketEncryption.go
@@ -175,6 +175,9 @@ func (c *Client) addOperationDeleteBucketEncryptionMiddlewares(stack *middleware
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_DeleteBucketIntelligentTieringConfiguration.go
+++ b/service/s3/api_op_DeleteBucketIntelligentTieringConfiguration.go
@@ -157,6 +157,9 @@ func (c *Client) addOperationDeleteBucketIntelligentTieringConfigurationMiddlewa
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_DeleteBucketInventoryConfiguration.go
+++ b/service/s3/api_op_DeleteBucketInventoryConfiguration.go
@@ -190,6 +190,9 @@ func (c *Client) addOperationDeleteBucketInventoryConfigurationMiddlewares(stack
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_DeleteBucketLifecycle.go
+++ b/service/s3/api_op_DeleteBucketLifecycle.go
@@ -177,6 +177,9 @@ func (c *Client) addOperationDeleteBucketLifecycleMiddlewares(stack *middleware.
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_DeleteBucketMetadataConfiguration.go
+++ b/service/s3/api_op_DeleteBucketMetadataConfiguration.go
@@ -150,6 +150,9 @@ func (c *Client) addOperationDeleteBucketMetadataConfigurationMiddlewares(stack 
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_DeleteBucketMetadataTableConfiguration.go
+++ b/service/s3/api_op_DeleteBucketMetadataTableConfiguration.go
@@ -157,6 +157,9 @@ func (c *Client) addOperationDeleteBucketMetadataTableConfigurationMiddlewares(s
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_DeleteBucketMetricsConfiguration.go
+++ b/service/s3/api_op_DeleteBucketMetricsConfiguration.go
@@ -192,6 +192,9 @@ func (c *Client) addOperationDeleteBucketMetricsConfigurationMiddlewares(stack *
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_DeleteBucketOwnershipControls.go
+++ b/service/s3/api_op_DeleteBucketOwnershipControls.go
@@ -135,6 +135,9 @@ func (c *Client) addOperationDeleteBucketOwnershipControlsMiddlewares(stack *mid
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_DeleteBucketPolicy.go
+++ b/service/s3/api_op_DeleteBucketPolicy.go
@@ -187,6 +187,9 @@ func (c *Client) addOperationDeleteBucketPolicyMiddlewares(stack *middleware.Sta
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_DeleteBucketReplication.go
+++ b/service/s3/api_op_DeleteBucketReplication.go
@@ -145,6 +145,9 @@ func (c *Client) addOperationDeleteBucketReplicationMiddlewares(stack *middlewar
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_DeleteBucketTagging.go
+++ b/service/s3/api_op_DeleteBucketTagging.go
@@ -139,6 +139,9 @@ func (c *Client) addOperationDeleteBucketTaggingMiddlewares(stack *middleware.St
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_DeleteBucketWebsite.go
+++ b/service/s3/api_op_DeleteBucketWebsite.go
@@ -144,6 +144,9 @@ func (c *Client) addOperationDeleteBucketWebsiteMiddlewares(stack *middleware.St
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_DeleteObject.go
+++ b/service/s3/api_op_DeleteObject.go
@@ -350,6 +350,9 @@ func (c *Client) addOperationDeleteObjectMiddlewares(stack *middleware.Stack, op
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_DeleteObject.go
+++ b/service/s3/api_op_DeleteObject.go
@@ -350,9 +350,6 @@ func (c *Client) addOperationDeleteObjectMiddlewares(stack *middleware.Stack, op
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
-	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
-		return err
-	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_DeleteObjectAnnotation.go
+++ b/service/s3/api_op_DeleteObjectAnnotation.go
@@ -184,6 +184,9 @@ func (c *Client) addOperationDeleteObjectAnnotationMiddlewares(stack *middleware
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_DeleteObjectTagging.go
+++ b/service/s3/api_op_DeleteObjectTagging.go
@@ -172,6 +172,9 @@ func (c *Client) addOperationDeleteObjectTaggingMiddlewares(stack *middleware.St
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_DeleteObjects.go
+++ b/service/s3/api_op_DeleteObjects.go
@@ -365,6 +365,9 @@ func (c *Client) addOperationDeleteObjectsMiddlewares(stack *middleware.Stack, o
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_DeleteObjects.go
+++ b/service/s3/api_op_DeleteObjects.go
@@ -365,9 +365,6 @@ func (c *Client) addOperationDeleteObjectsMiddlewares(stack *middleware.Stack, o
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
-	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
-		return err
-	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_DeletePublicAccessBlock.go
+++ b/service/s3/api_op_DeletePublicAccessBlock.go
@@ -144,6 +144,9 @@ func (c *Client) addOperationDeletePublicAccessBlockMiddlewares(stack *middlewar
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_GetBucketAbac.go
+++ b/service/s3/api_op_GetBucketAbac.go
@@ -122,6 +122,9 @@ func (c *Client) addOperationGetBucketAbacMiddlewares(stack *middleware.Stack, o
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_GetBucketAccelerateConfiguration.go
+++ b/service/s3/api_op_GetBucketAccelerateConfiguration.go
@@ -174,6 +174,9 @@ func (c *Client) addOperationGetBucketAccelerateConfigurationMiddlewares(stack *
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_GetBucketAccelerateConfiguration.go
+++ b/service/s3/api_op_GetBucketAccelerateConfiguration.go
@@ -174,9 +174,6 @@ func (c *Client) addOperationGetBucketAccelerateConfigurationMiddlewares(stack *
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
-	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
-		return err
-	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_GetBucketAcl.go
+++ b/service/s3/api_op_GetBucketAcl.go
@@ -167,9 +167,6 @@ func (c *Client) addOperationGetBucketAclMiddlewares(stack *middleware.Stack, op
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
-	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
-		return err
-	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_GetBucketAcl.go
+++ b/service/s3/api_op_GetBucketAcl.go
@@ -167,6 +167,9 @@ func (c *Client) addOperationGetBucketAclMiddlewares(stack *middleware.Stack, op
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_GetBucketAnalyticsConfiguration.go
+++ b/service/s3/api_op_GetBucketAnalyticsConfiguration.go
@@ -156,6 +156,9 @@ func (c *Client) addOperationGetBucketAnalyticsConfigurationMiddlewares(stack *m
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_GetBucketCors.go
+++ b/service/s3/api_op_GetBucketCors.go
@@ -166,9 +166,6 @@ func (c *Client) addOperationGetBucketCorsMiddlewares(stack *middleware.Stack, o
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
-	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
-		return err
-	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_GetBucketCors.go
+++ b/service/s3/api_op_GetBucketCors.go
@@ -166,6 +166,9 @@ func (c *Client) addOperationGetBucketCorsMiddlewares(stack *middleware.Stack, o
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_GetBucketEncryption.go
+++ b/service/s3/api_op_GetBucketEncryption.go
@@ -184,6 +184,9 @@ func (c *Client) addOperationGetBucketEncryptionMiddlewares(stack *middleware.St
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_GetBucketEncryption.go
+++ b/service/s3/api_op_GetBucketEncryption.go
@@ -184,9 +184,6 @@ func (c *Client) addOperationGetBucketEncryptionMiddlewares(stack *middleware.St
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
-	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
-		return err
-	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_GetBucketIntelligentTieringConfiguration.go
+++ b/service/s3/api_op_GetBucketIntelligentTieringConfiguration.go
@@ -162,6 +162,9 @@ func (c *Client) addOperationGetBucketIntelligentTieringConfigurationMiddlewares
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_GetBucketInventoryConfiguration.go
+++ b/service/s3/api_op_GetBucketInventoryConfiguration.go
@@ -191,6 +191,9 @@ func (c *Client) addOperationGetBucketInventoryConfigurationMiddlewares(stack *m
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_GetBucketLifecycleConfiguration.go
+++ b/service/s3/api_op_GetBucketLifecycleConfiguration.go
@@ -221,6 +221,9 @@ func (c *Client) addOperationGetBucketLifecycleConfigurationMiddlewares(stack *m
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_GetBucketLifecycleConfiguration.go
+++ b/service/s3/api_op_GetBucketLifecycleConfiguration.go
@@ -221,9 +221,6 @@ func (c *Client) addOperationGetBucketLifecycleConfigurationMiddlewares(stack *m
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
-	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
-		return err
-	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_GetBucketLocation.go
+++ b/service/s3/api_op_GetBucketLocation.go
@@ -189,9 +189,6 @@ func (c *Client) addOperationGetBucketLocationMiddlewares(stack *middleware.Stac
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
-	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
-		return err
-	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_GetBucketLocation.go
+++ b/service/s3/api_op_GetBucketLocation.go
@@ -189,6 +189,9 @@ func (c *Client) addOperationGetBucketLocationMiddlewares(stack *middleware.Stac
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_GetBucketLogging.go
+++ b/service/s3/api_op_GetBucketLogging.go
@@ -141,6 +141,9 @@ func (c *Client) addOperationGetBucketLoggingMiddlewares(stack *middleware.Stack
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_GetBucketLogging.go
+++ b/service/s3/api_op_GetBucketLogging.go
@@ -141,9 +141,6 @@ func (c *Client) addOperationGetBucketLoggingMiddlewares(stack *middleware.Stack
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
-	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
-		return err
-	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_GetBucketMetadataConfiguration.go
+++ b/service/s3/api_op_GetBucketMetadataConfiguration.go
@@ -154,6 +154,9 @@ func (c *Client) addOperationGetBucketMetadataConfigurationMiddlewares(stack *mi
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_GetBucketMetadataTableConfiguration.go
+++ b/service/s3/api_op_GetBucketMetadataTableConfiguration.go
@@ -162,6 +162,9 @@ func (c *Client) addOperationGetBucketMetadataTableConfigurationMiddlewares(stac
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_GetBucketMetricsConfiguration.go
+++ b/service/s3/api_op_GetBucketMetricsConfiguration.go
@@ -196,6 +196,9 @@ func (c *Client) addOperationGetBucketMetricsConfigurationMiddlewares(stack *mid
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_GetBucketNotificationConfiguration.go
+++ b/service/s3/api_op_GetBucketNotificationConfiguration.go
@@ -181,9 +181,6 @@ func (c *Client) addOperationGetBucketNotificationConfigurationMiddlewares(stack
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
-	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
-		return err
-	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_GetBucketNotificationConfiguration.go
+++ b/service/s3/api_op_GetBucketNotificationConfiguration.go
@@ -181,6 +181,9 @@ func (c *Client) addOperationGetBucketNotificationConfigurationMiddlewares(stack
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_GetBucketOwnershipControls.go
+++ b/service/s3/api_op_GetBucketOwnershipControls.go
@@ -151,9 +151,6 @@ func (c *Client) addOperationGetBucketOwnershipControlsMiddlewares(stack *middle
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
-	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
-		return err
-	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_GetBucketOwnershipControls.go
+++ b/service/s3/api_op_GetBucketOwnershipControls.go
@@ -151,6 +151,9 @@ func (c *Client) addOperationGetBucketOwnershipControlsMiddlewares(stack *middle
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_GetBucketPolicyStatus.go
+++ b/service/s3/api_op_GetBucketPolicyStatus.go
@@ -149,6 +149,9 @@ func (c *Client) addOperationGetBucketPolicyStatusMiddlewares(stack *middleware.
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_GetBucketPolicyStatus.go
+++ b/service/s3/api_op_GetBucketPolicyStatus.go
@@ -149,9 +149,6 @@ func (c *Client) addOperationGetBucketPolicyStatusMiddlewares(stack *middleware.
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
-	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
-		return err
-	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_GetBucketReplication.go
+++ b/service/s3/api_op_GetBucketReplication.go
@@ -156,9 +156,6 @@ func (c *Client) addOperationGetBucketReplicationMiddlewares(stack *middleware.S
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
-	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
-		return err
-	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_GetBucketReplication.go
+++ b/service/s3/api_op_GetBucketReplication.go
@@ -156,6 +156,9 @@ func (c *Client) addOperationGetBucketReplicationMiddlewares(stack *middleware.S
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_GetBucketRequestPayment.go
+++ b/service/s3/api_op_GetBucketRequestPayment.go
@@ -135,6 +135,9 @@ func (c *Client) addOperationGetBucketRequestPaymentMiddlewares(stack *middlewar
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_GetBucketRequestPayment.go
+++ b/service/s3/api_op_GetBucketRequestPayment.go
@@ -135,9 +135,6 @@ func (c *Client) addOperationGetBucketRequestPaymentMiddlewares(stack *middlewar
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
-	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
-		return err
-	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_GetBucketTagging.go
+++ b/service/s3/api_op_GetBucketTagging.go
@@ -148,6 +148,9 @@ func (c *Client) addOperationGetBucketTaggingMiddlewares(stack *middleware.Stack
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_GetBucketVersioning.go
+++ b/service/s3/api_op_GetBucketVersioning.go
@@ -150,6 +150,9 @@ func (c *Client) addOperationGetBucketVersioningMiddlewares(stack *middleware.St
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_GetBucketVersioning.go
+++ b/service/s3/api_op_GetBucketVersioning.go
@@ -150,9 +150,6 @@ func (c *Client) addOperationGetBucketVersioningMiddlewares(stack *middleware.St
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
-	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
-		return err
-	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_GetBucketWebsite.go
+++ b/service/s3/api_op_GetBucketWebsite.go
@@ -154,6 +154,9 @@ func (c *Client) addOperationGetBucketWebsiteMiddlewares(stack *middleware.Stack
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_GetBucketWebsite.go
+++ b/service/s3/api_op_GetBucketWebsite.go
@@ -154,9 +154,6 @@ func (c *Client) addOperationGetBucketWebsiteMiddlewares(stack *middleware.Stack
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
-	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
-		return err
-	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_GetObjectAcl.go
+++ b/service/s3/api_op_GetObjectAcl.go
@@ -203,6 +203,9 @@ func (c *Client) addOperationGetObjectAclMiddlewares(stack *middleware.Stack, op
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_GetObjectAttributes.go
+++ b/service/s3/api_op_GetObjectAttributes.go
@@ -429,6 +429,9 @@ func (c *Client) addOperationGetObjectAttributesMiddlewares(stack *middleware.St
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_GetObjectLegalHold.go
+++ b/service/s3/api_op_GetObjectLegalHold.go
@@ -168,6 +168,9 @@ func (c *Client) addOperationGetObjectLegalHoldMiddlewares(stack *middleware.Sta
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_GetObjectLockConfiguration.go
+++ b/service/s3/api_op_GetObjectLockConfiguration.go
@@ -148,6 +148,9 @@ func (c *Client) addOperationGetObjectLockConfigurationMiddlewares(stack *middle
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_GetObjectLockConfiguration.go
+++ b/service/s3/api_op_GetObjectLockConfiguration.go
@@ -148,9 +148,6 @@ func (c *Client) addOperationGetObjectLockConfigurationMiddlewares(stack *middle
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
-	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
-		return err
-	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_GetObjectRetention.go
+++ b/service/s3/api_op_GetObjectRetention.go
@@ -168,6 +168,9 @@ func (c *Client) addOperationGetObjectRetentionMiddlewares(stack *middleware.Sta
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_GetObjectTagging.go
+++ b/service/s3/api_op_GetObjectTagging.go
@@ -197,6 +197,9 @@ func (c *Client) addOperationGetObjectTaggingMiddlewares(stack *middleware.Stack
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_GetObjectTagging.go
+++ b/service/s3/api_op_GetObjectTagging.go
@@ -197,9 +197,6 @@ func (c *Client) addOperationGetObjectTaggingMiddlewares(stack *middleware.Stack
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
-	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
-		return err
-	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_GetPublicAccessBlock.go
+++ b/service/s3/api_op_GetPublicAccessBlock.go
@@ -162,6 +162,9 @@ func (c *Client) addOperationGetPublicAccessBlockMiddlewares(stack *middleware.S
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_HeadBucket.go
+++ b/service/s3/api_op_HeadBucket.go
@@ -257,6 +257,9 @@ func (c *Client) addOperationHeadBucketMiddlewares(stack *middleware.Stack, opti
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_HeadBucket.go
+++ b/service/s3/api_op_HeadBucket.go
@@ -257,9 +257,6 @@ func (c *Client) addOperationHeadBucketMiddlewares(stack *middleware.Stack, opti
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
-	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
-		return err
-	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_HeadObject.go
+++ b/service/s3/api_op_HeadObject.go
@@ -769,9 +769,6 @@ func (c *Client) addOperationHeadObjectMiddlewares(stack *middleware.Stack, opti
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
-	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
-		return err
-	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_HeadObject.go
+++ b/service/s3/api_op_HeadObject.go
@@ -769,6 +769,9 @@ func (c *Client) addOperationHeadObjectMiddlewares(stack *middleware.Stack, opti
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_ListBucketAnalyticsConfigurations.go
+++ b/service/s3/api_op_ListBucketAnalyticsConfigurations.go
@@ -176,6 +176,9 @@ func (c *Client) addOperationListBucketAnalyticsConfigurationsMiddlewares(stack 
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_ListBucketIntelligentTieringConfigurations.go
+++ b/service/s3/api_op_ListBucketIntelligentTieringConfigurations.go
@@ -175,6 +175,9 @@ func (c *Client) addOperationListBucketIntelligentTieringConfigurationsMiddlewar
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_ListBucketInventoryConfigurations.go
+++ b/service/s3/api_op_ListBucketInventoryConfigurations.go
@@ -214,6 +214,9 @@ func (c *Client) addOperationListBucketInventoryConfigurationsMiddlewares(stack 
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_ListBucketMetricsConfigurations.go
+++ b/service/s3/api_op_ListBucketMetricsConfigurations.go
@@ -219,6 +219,9 @@ func (c *Client) addOperationListBucketMetricsConfigurationsMiddlewares(stack *m
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_ListBuckets.go
+++ b/service/s3/api_op_ListBuckets.go
@@ -173,9 +173,6 @@ func (c *Client) addOperationListBucketsMiddlewares(stack *middleware.Stack, opt
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
-	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
-		return err
-	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_ListBuckets.go
+++ b/service/s3/api_op_ListBuckets.go
@@ -173,6 +173,9 @@ func (c *Client) addOperationListBucketsMiddlewares(stack *middleware.Stack, opt
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_ListDirectoryBuckets.go
+++ b/service/s3/api_op_ListDirectoryBuckets.go
@@ -153,6 +153,9 @@ func (c *Client) addOperationListDirectoryBucketsMiddlewares(stack *middleware.S
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_ListDirectoryBuckets.go
+++ b/service/s3/api_op_ListDirectoryBuckets.go
@@ -153,9 +153,6 @@ func (c *Client) addOperationListDirectoryBucketsMiddlewares(stack *middleware.S
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
-	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
-		return err
-	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_ListMultipartUploads.go
+++ b/service/s3/api_op_ListMultipartUploads.go
@@ -416,6 +416,9 @@ func (c *Client) addOperationListMultipartUploadsMiddlewares(stack *middleware.S
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_ListObjectAnnotations.go
+++ b/service/s3/api_op_ListObjectAnnotations.go
@@ -200,6 +200,9 @@ func (c *Client) addOperationListObjectAnnotationsMiddlewares(stack *middleware.
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_ListObjectVersions.go
+++ b/service/s3/api_op_ListObjectVersions.go
@@ -281,9 +281,6 @@ func (c *Client) addOperationListObjectVersionsMiddlewares(stack *middleware.Sta
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
-	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
-		return err
-	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_ListObjectVersions.go
+++ b/service/s3/api_op_ListObjectVersions.go
@@ -281,6 +281,9 @@ func (c *Client) addOperationListObjectVersionsMiddlewares(stack *middleware.Sta
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_ListObjects.go
+++ b/service/s3/api_op_ListObjects.go
@@ -306,6 +306,9 @@ func (c *Client) addOperationListObjectsMiddlewares(stack *middleware.Stack, opt
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_ListObjects.go
+++ b/service/s3/api_op_ListObjects.go
@@ -306,9 +306,6 @@ func (c *Client) addOperationListObjectsMiddlewares(stack *middleware.Stack, opt
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
-	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
-		return err
-	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_ListObjectsV2.go
+++ b/service/s3/api_op_ListObjectsV2.go
@@ -401,9 +401,6 @@ func (c *Client) addOperationListObjectsV2Middlewares(stack *middleware.Stack, o
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
-	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
-		return err
-	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_ListObjectsV2.go
+++ b/service/s3/api_op_ListObjectsV2.go
@@ -401,6 +401,9 @@ func (c *Client) addOperationListObjectsV2Middlewares(stack *middleware.Stack, o
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_ListParts.go
+++ b/service/s3/api_op_ListParts.go
@@ -380,6 +380,9 @@ func (c *Client) addOperationListPartsMiddlewares(stack *middleware.Stack, optio
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_PutBucketAbac.go
+++ b/service/s3/api_op_PutBucketAbac.go
@@ -155,6 +155,9 @@ func (c *Client) addOperationPutBucketAbacMiddlewares(stack *middleware.Stack, o
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_PutBucketAccelerateConfiguration.go
+++ b/service/s3/api_op_PutBucketAccelerateConfiguration.go
@@ -184,6 +184,9 @@ func (c *Client) addOperationPutBucketAccelerateConfigurationMiddlewares(stack *
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_PutBucketAcl.go
+++ b/service/s3/api_op_PutBucketAcl.go
@@ -341,6 +341,9 @@ func (c *Client) addOperationPutBucketAclMiddlewares(stack *middleware.Stack, op
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_PutBucketAcl.go
+++ b/service/s3/api_op_PutBucketAcl.go
@@ -341,9 +341,6 @@ func (c *Client) addOperationPutBucketAclMiddlewares(stack *middleware.Stack, op
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
-	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
-		return err
-	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_PutBucketAnalyticsConfiguration.go
+++ b/service/s3/api_op_PutBucketAnalyticsConfiguration.go
@@ -191,6 +191,9 @@ func (c *Client) addOperationPutBucketAnalyticsConfigurationMiddlewares(stack *m
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_PutBucketAnalyticsConfiguration.go
+++ b/service/s3/api_op_PutBucketAnalyticsConfiguration.go
@@ -191,9 +191,6 @@ func (c *Client) addOperationPutBucketAnalyticsConfigurationMiddlewares(stack *m
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
-	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
-		return err
-	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_PutBucketCors.go
+++ b/service/s3/api_op_PutBucketCors.go
@@ -206,6 +206,9 @@ func (c *Client) addOperationPutBucketCorsMiddlewares(stack *middleware.Stack, o
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_PutBucketEncryption.go
+++ b/service/s3/api_op_PutBucketEncryption.go
@@ -284,9 +284,6 @@ func (c *Client) addOperationPutBucketEncryptionMiddlewares(stack *middleware.St
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
-	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
-		return err
-	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_PutBucketEncryption.go
+++ b/service/s3/api_op_PutBucketEncryption.go
@@ -284,6 +284,9 @@ func (c *Client) addOperationPutBucketEncryptionMiddlewares(stack *middleware.St
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_PutBucketIntelligentTieringConfiguration.go
+++ b/service/s3/api_op_PutBucketIntelligentTieringConfiguration.go
@@ -183,6 +183,9 @@ func (c *Client) addOperationPutBucketIntelligentTieringConfigurationMiddlewares
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_PutBucketInventoryConfiguration.go
+++ b/service/s3/api_op_PutBucketInventoryConfiguration.go
@@ -236,6 +236,9 @@ func (c *Client) addOperationPutBucketInventoryConfigurationMiddlewares(stack *m
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_PutBucketLifecycleConfiguration.go
+++ b/service/s3/api_op_PutBucketLifecycleConfiguration.go
@@ -293,6 +293,9 @@ func (c *Client) addOperationPutBucketLifecycleConfigurationMiddlewares(stack *m
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_PutBucketLogging.go
+++ b/service/s3/api_op_PutBucketLogging.go
@@ -226,6 +226,9 @@ func (c *Client) addOperationPutBucketLoggingMiddlewares(stack *middleware.Stack
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_PutBucketMetricsConfiguration.go
+++ b/service/s3/api_op_PutBucketMetricsConfiguration.go
@@ -207,6 +207,9 @@ func (c *Client) addOperationPutBucketMetricsConfigurationMiddlewares(stack *mid
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_PutBucketNotificationConfiguration.go
+++ b/service/s3/api_op_PutBucketNotificationConfiguration.go
@@ -183,6 +183,9 @@ func (c *Client) addOperationPutBucketNotificationConfigurationMiddlewares(stack
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_PutBucketOwnershipControls.go
+++ b/service/s3/api_op_PutBucketOwnershipControls.go
@@ -168,6 +168,9 @@ func (c *Client) addOperationPutBucketOwnershipControlsMiddlewares(stack *middle
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_PutBucketPolicy.go
+++ b/service/s3/api_op_PutBucketPolicy.go
@@ -266,6 +266,9 @@ func (c *Client) addOperationPutBucketPolicyMiddlewares(stack *middleware.Stack,
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_PutBucketPolicy.go
+++ b/service/s3/api_op_PutBucketPolicy.go
@@ -266,9 +266,6 @@ func (c *Client) addOperationPutBucketPolicyMiddlewares(stack *middleware.Stack,
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
-	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
-		return err
-	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_PutBucketReplication.go
+++ b/service/s3/api_op_PutBucketReplication.go
@@ -224,6 +224,9 @@ func (c *Client) addOperationPutBucketReplicationMiddlewares(stack *middleware.S
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_PutBucketRequestPayment.go
+++ b/service/s3/api_op_PutBucketRequestPayment.go
@@ -171,6 +171,9 @@ func (c *Client) addOperationPutBucketRequestPaymentMiddlewares(stack *middlewar
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_PutBucketTagging.go
+++ b/service/s3/api_op_PutBucketTagging.go
@@ -208,6 +208,9 @@ func (c *Client) addOperationPutBucketTaggingMiddlewares(stack *middleware.Stack
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_PutBucketVersioning.go
+++ b/service/s3/api_op_PutBucketVersioning.go
@@ -214,6 +214,9 @@ func (c *Client) addOperationPutBucketVersioningMiddlewares(stack *middleware.St
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_PutBucketWebsite.go
+++ b/service/s3/api_op_PutBucketWebsite.go
@@ -226,6 +226,9 @@ func (c *Client) addOperationPutBucketWebsiteMiddlewares(stack *middleware.Stack
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_PutObject.go
+++ b/service/s3/api_op_PutObject.go
@@ -1001,9 +1001,6 @@ func (c *Client) addOperationPutObjectMiddlewares(stack *middleware.Stack, optio
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
-	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
-		return err
-	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_PutObject.go
+++ b/service/s3/api_op_PutObject.go
@@ -1001,6 +1001,9 @@ func (c *Client) addOperationPutObjectMiddlewares(stack *middleware.Stack, optio
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_PutObjectAcl.go
+++ b/service/s3/api_op_PutObjectAcl.go
@@ -396,9 +396,6 @@ func (c *Client) addOperationPutObjectAclMiddlewares(stack *middleware.Stack, op
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
-	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
-		return err
-	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_PutObjectAcl.go
+++ b/service/s3/api_op_PutObjectAcl.go
@@ -396,6 +396,9 @@ func (c *Client) addOperationPutObjectAclMiddlewares(stack *middleware.Stack, op
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_PutObjectAnnotation.go
+++ b/service/s3/api_op_PutObjectAnnotation.go
@@ -289,6 +289,9 @@ func (c *Client) addOperationPutObjectAnnotationMiddlewares(stack *middleware.St
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_PutObjectLegalHold.go
+++ b/service/s3/api_op_PutObjectLegalHold.go
@@ -199,6 +199,9 @@ func (c *Client) addOperationPutObjectLegalHoldMiddlewares(stack *middleware.Sta
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_PutObjectLockConfiguration.go
+++ b/service/s3/api_op_PutObjectLockConfiguration.go
@@ -188,6 +188,9 @@ func (c *Client) addOperationPutObjectLockConfigurationMiddlewares(stack *middle
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_PutObjectRetention.go
+++ b/service/s3/api_op_PutObjectRetention.go
@@ -206,9 +206,6 @@ func (c *Client) addOperationPutObjectRetentionMiddlewares(stack *middleware.Sta
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
-	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
-		return err
-	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_PutObjectRetention.go
+++ b/service/s3/api_op_PutObjectRetention.go
@@ -206,6 +206,9 @@ func (c *Client) addOperationPutObjectRetentionMiddlewares(stack *middleware.Sta
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_PutObjectTagging.go
+++ b/service/s3/api_op_PutObjectTagging.go
@@ -232,9 +232,6 @@ func (c *Client) addOperationPutObjectTaggingMiddlewares(stack *middleware.Stack
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
-	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
-		return err
-	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_PutObjectTagging.go
+++ b/service/s3/api_op_PutObjectTagging.go
@@ -232,6 +232,9 @@ func (c *Client) addOperationPutObjectTaggingMiddlewares(stack *middleware.Stack
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_PutPublicAccessBlock.go
+++ b/service/s3/api_op_PutPublicAccessBlock.go
@@ -190,6 +190,9 @@ func (c *Client) addOperationPutPublicAccessBlockMiddlewares(stack *middleware.S
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_RenameObject.go
+++ b/service/s3/api_op_RenameObject.go
@@ -235,6 +235,9 @@ func (c *Client) addOperationRenameObjectMiddlewares(stack *middleware.Stack, op
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_RestoreObject.go
+++ b/service/s3/api_op_RestoreObject.go
@@ -342,6 +342,9 @@ func (c *Client) addOperationRestoreObjectMiddlewares(stack *middleware.Stack, o
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_UpdateBucketMetadataAnnotationTableConfiguration.go
+++ b/service/s3/api_op_UpdateBucketMetadataAnnotationTableConfiguration.go
@@ -159,6 +159,9 @@ func (c *Client) addOperationUpdateBucketMetadataAnnotationTableConfigurationMid
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_UpdateBucketMetadataInventoryTableConfiguration.go
+++ b/service/s3/api_op_UpdateBucketMetadataInventoryTableConfiguration.go
@@ -182,6 +182,9 @@ func (c *Client) addOperationUpdateBucketMetadataInventoryTableConfigurationMidd
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_UpdateBucketMetadataJournalTableConfiguration.go
+++ b/service/s3/api_op_UpdateBucketMetadataJournalTableConfiguration.go
@@ -164,6 +164,9 @@ func (c *Client) addOperationUpdateBucketMetadataJournalTableConfigurationMiddle
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_UpdateObjectEncryption.go
+++ b/service/s3/api_op_UpdateObjectEncryption.go
@@ -308,6 +308,9 @@ func (c *Client) addOperationUpdateObjectEncryptionMiddlewares(stack *middleware
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_UploadPart.go
+++ b/service/s3/api_op_UploadPart.go
@@ -603,6 +603,9 @@ func (c *Client) addOperationUploadPartMiddlewares(stack *middleware.Stack, opti
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_UploadPart.go
+++ b/service/s3/api_op_UploadPart.go
@@ -603,9 +603,6 @@ func (c *Client) addOperationUploadPartMiddlewares(stack *middleware.Stack, opti
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
-	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
-		return err
-	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/api_op_WriteGetObjectResponse.go
+++ b/service/s3/api_op_WriteGetObjectResponse.go
@@ -462,6 +462,9 @@ func (c *Client) addOperationWriteGetObjectResponseMiddlewares(stack *middleware
 	if err = disableAcceptEncodingGzip(stack); err != nil {
 		return err
 	}
+	if err = s3cust.HandleResponseErrorWith200Status(stack); err != nil {
+		return err
+	}
 	if err = addRequestResponseLogging(stack, options); err != nil {
 		return err
 	}

--- a/service/s3/internal/customizations/handle_200_error.go
+++ b/service/s3/internal/customizations/handle_200_error.go
@@ -54,9 +54,8 @@ func (m *processResponseFor200ErrorMiddleware) HandleDeserialize(
 	rootDecoder := xml.NewDecoder(body)
 	t, err := smithyxml.FetchRootElement(rootDecoder)
 	if err == io.EOF {
-		return out, metadata, &smithy.DeserializationError{
-			Err: fmt.Errorf("received empty response payload"),
-		}
+		// Empty body is not an error, continue normal response handling.
+		return out, metadata, nil
 	}
 
 	// rewind response body

--- a/service/s3/internal/customizations/handle_200_error_test.go
+++ b/service/s3/internal/customizations/handle_200_error_test.go
@@ -59,7 +59,7 @@ func TestErrorResponseWith200StatusCode(t *testing.T) {
 				StatusCode: 200,
 				Body:       asReadCloser(""),
 			},
-			expectedError: "received empty response payload",
+			expectedError: "",
 		},
 		"200InvalidResponse": {
 			response: &http.Response{

--- a/service/s3/snapshot/api_op_AbortMultipartUpload.go.snap
+++ b/service/s3/snapshot/api_op_AbortMultipartUpload.go.snap
@@ -44,5 +44,6 @@ AbortMultipartUpload
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_CreateBucket.go.snap
+++ b/service/s3/snapshot/api_op_CreateBucket.go.snap
@@ -44,5 +44,6 @@ CreateBucket
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_CreateBucket.go.snap
+++ b/service/s3/snapshot/api_op_CreateBucket.go.snap
@@ -44,6 +44,5 @@ CreateBucket
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
-		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_CreateBucketMetadataConfiguration.go.snap
+++ b/service/s3/snapshot/api_op_CreateBucketMetadataConfiguration.go.snap
@@ -48,5 +48,6 @@ CreateBucketMetadataConfiguration
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_CreateBucketMetadataTableConfiguration.go.snap
+++ b/service/s3/snapshot/api_op_CreateBucketMetadataTableConfiguration.go.snap
@@ -48,5 +48,6 @@ CreateBucketMetadataTableConfiguration
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_CreateMultipartUpload.go.snap
+++ b/service/s3/snapshot/api_op_CreateMultipartUpload.go.snap
@@ -45,6 +45,5 @@ CreateMultipartUpload
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
-		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_CreateMultipartUpload.go.snap
+++ b/service/s3/snapshot/api_op_CreateMultipartUpload.go.snap
@@ -45,5 +45,6 @@ CreateMultipartUpload
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_CreateSession.go.snap
+++ b/service/s3/snapshot/api_op_CreateSession.go.snap
@@ -44,5 +44,6 @@ CreateSession
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_DeleteBucket.go.snap
+++ b/service/s3/snapshot/api_op_DeleteBucket.go.snap
@@ -44,5 +44,6 @@ DeleteBucket
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_DeleteBucketAnalyticsConfiguration.go.snap
+++ b/service/s3/snapshot/api_op_DeleteBucketAnalyticsConfiguration.go.snap
@@ -44,5 +44,6 @@ DeleteBucketAnalyticsConfiguration
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_DeleteBucketCors.go.snap
+++ b/service/s3/snapshot/api_op_DeleteBucketCors.go.snap
@@ -44,5 +44,6 @@ DeleteBucketCors
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_DeleteBucketEncryption.go.snap
+++ b/service/s3/snapshot/api_op_DeleteBucketEncryption.go.snap
@@ -44,5 +44,6 @@ DeleteBucketEncryption
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_DeleteBucketIntelligentTieringConfiguration.go.snap
+++ b/service/s3/snapshot/api_op_DeleteBucketIntelligentTieringConfiguration.go.snap
@@ -44,5 +44,6 @@ DeleteBucketIntelligentTieringConfiguration
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_DeleteBucketInventoryConfiguration.go.snap
+++ b/service/s3/snapshot/api_op_DeleteBucketInventoryConfiguration.go.snap
@@ -44,5 +44,6 @@ DeleteBucketInventoryConfiguration
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_DeleteBucketLifecycle.go.snap
+++ b/service/s3/snapshot/api_op_DeleteBucketLifecycle.go.snap
@@ -44,5 +44,6 @@ DeleteBucketLifecycle
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_DeleteBucketMetadataConfiguration.go.snap
+++ b/service/s3/snapshot/api_op_DeleteBucketMetadataConfiguration.go.snap
@@ -44,5 +44,6 @@ DeleteBucketMetadataConfiguration
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_DeleteBucketMetadataTableConfiguration.go.snap
+++ b/service/s3/snapshot/api_op_DeleteBucketMetadataTableConfiguration.go.snap
@@ -44,5 +44,6 @@ DeleteBucketMetadataTableConfiguration
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_DeleteBucketMetricsConfiguration.go.snap
+++ b/service/s3/snapshot/api_op_DeleteBucketMetricsConfiguration.go.snap
@@ -44,5 +44,6 @@ DeleteBucketMetricsConfiguration
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_DeleteBucketOwnershipControls.go.snap
+++ b/service/s3/snapshot/api_op_DeleteBucketOwnershipControls.go.snap
@@ -44,5 +44,6 @@ DeleteBucketOwnershipControls
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_DeleteBucketPolicy.go.snap
+++ b/service/s3/snapshot/api_op_DeleteBucketPolicy.go.snap
@@ -44,5 +44,6 @@ DeleteBucketPolicy
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_DeleteBucketReplication.go.snap
+++ b/service/s3/snapshot/api_op_DeleteBucketReplication.go.snap
@@ -44,5 +44,6 @@ DeleteBucketReplication
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_DeleteBucketTagging.go.snap
+++ b/service/s3/snapshot/api_op_DeleteBucketTagging.go.snap
@@ -44,5 +44,6 @@ DeleteBucketTagging
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_DeleteBucketWebsite.go.snap
+++ b/service/s3/snapshot/api_op_DeleteBucketWebsite.go.snap
@@ -44,5 +44,6 @@ DeleteBucketWebsite
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_DeleteObject.go.snap
+++ b/service/s3/snapshot/api_op_DeleteObject.go.snap
@@ -44,6 +44,5 @@ DeleteObject
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
-		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_DeleteObject.go.snap
+++ b/service/s3/snapshot/api_op_DeleteObject.go.snap
@@ -44,5 +44,6 @@ DeleteObject
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_DeleteObjectAnnotation.go.snap
+++ b/service/s3/snapshot/api_op_DeleteObjectAnnotation.go.snap
@@ -44,5 +44,6 @@ DeleteObjectAnnotation
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_DeleteObjectTagging.go.snap
+++ b/service/s3/snapshot/api_op_DeleteObjectTagging.go.snap
@@ -44,5 +44,6 @@ DeleteObjectTagging
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_DeleteObjects.go.snap
+++ b/service/s3/snapshot/api_op_DeleteObjects.go.snap
@@ -48,5 +48,6 @@ DeleteObjects
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_DeleteObjects.go.snap
+++ b/service/s3/snapshot/api_op_DeleteObjects.go.snap
@@ -48,6 +48,5 @@ DeleteObjects
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
-		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_DeletePublicAccessBlock.go.snap
+++ b/service/s3/snapshot/api_op_DeletePublicAccessBlock.go.snap
@@ -44,5 +44,6 @@ DeletePublicAccessBlock
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_GetBucketAbac.go.snap
+++ b/service/s3/snapshot/api_op_GetBucketAbac.go.snap
@@ -44,5 +44,6 @@ GetBucketAbac
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_GetBucketAccelerateConfiguration.go.snap
+++ b/service/s3/snapshot/api_op_GetBucketAccelerateConfiguration.go.snap
@@ -44,6 +44,5 @@ GetBucketAccelerateConfiguration
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
-		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_GetBucketAccelerateConfiguration.go.snap
+++ b/service/s3/snapshot/api_op_GetBucketAccelerateConfiguration.go.snap
@@ -44,5 +44,6 @@ GetBucketAccelerateConfiguration
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_GetBucketAcl.go.snap
+++ b/service/s3/snapshot/api_op_GetBucketAcl.go.snap
@@ -44,6 +44,5 @@ GetBucketAcl
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
-		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_GetBucketAcl.go.snap
+++ b/service/s3/snapshot/api_op_GetBucketAcl.go.snap
@@ -44,5 +44,6 @@ GetBucketAcl
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_GetBucketAnalyticsConfiguration.go.snap
+++ b/service/s3/snapshot/api_op_GetBucketAnalyticsConfiguration.go.snap
@@ -44,5 +44,6 @@ GetBucketAnalyticsConfiguration
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_GetBucketCors.go.snap
+++ b/service/s3/snapshot/api_op_GetBucketCors.go.snap
@@ -44,6 +44,5 @@ GetBucketCors
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
-		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_GetBucketCors.go.snap
+++ b/service/s3/snapshot/api_op_GetBucketCors.go.snap
@@ -44,5 +44,6 @@ GetBucketCors
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_GetBucketEncryption.go.snap
+++ b/service/s3/snapshot/api_op_GetBucketEncryption.go.snap
@@ -44,6 +44,5 @@ GetBucketEncryption
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
-		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_GetBucketEncryption.go.snap
+++ b/service/s3/snapshot/api_op_GetBucketEncryption.go.snap
@@ -44,5 +44,6 @@ GetBucketEncryption
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_GetBucketIntelligentTieringConfiguration.go.snap
+++ b/service/s3/snapshot/api_op_GetBucketIntelligentTieringConfiguration.go.snap
@@ -44,5 +44,6 @@ GetBucketIntelligentTieringConfiguration
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_GetBucketInventoryConfiguration.go.snap
+++ b/service/s3/snapshot/api_op_GetBucketInventoryConfiguration.go.snap
@@ -44,5 +44,6 @@ GetBucketInventoryConfiguration
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_GetBucketLifecycleConfiguration.go.snap
+++ b/service/s3/snapshot/api_op_GetBucketLifecycleConfiguration.go.snap
@@ -44,6 +44,5 @@ GetBucketLifecycleConfiguration
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
-		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_GetBucketLifecycleConfiguration.go.snap
+++ b/service/s3/snapshot/api_op_GetBucketLifecycleConfiguration.go.snap
@@ -44,5 +44,6 @@ GetBucketLifecycleConfiguration
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_GetBucketLocation.go.snap
+++ b/service/s3/snapshot/api_op_GetBucketLocation.go.snap
@@ -44,5 +44,6 @@ GetBucketLocation
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_GetBucketLocation.go.snap
+++ b/service/s3/snapshot/api_op_GetBucketLocation.go.snap
@@ -44,6 +44,5 @@ GetBucketLocation
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
-		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_GetBucketLogging.go.snap
+++ b/service/s3/snapshot/api_op_GetBucketLogging.go.snap
@@ -44,5 +44,6 @@ GetBucketLogging
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_GetBucketLogging.go.snap
+++ b/service/s3/snapshot/api_op_GetBucketLogging.go.snap
@@ -44,6 +44,5 @@ GetBucketLogging
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
-		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_GetBucketMetadataConfiguration.go.snap
+++ b/service/s3/snapshot/api_op_GetBucketMetadataConfiguration.go.snap
@@ -44,5 +44,6 @@ GetBucketMetadataConfiguration
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_GetBucketMetadataTableConfiguration.go.snap
+++ b/service/s3/snapshot/api_op_GetBucketMetadataTableConfiguration.go.snap
@@ -44,5 +44,6 @@ GetBucketMetadataTableConfiguration
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_GetBucketMetricsConfiguration.go.snap
+++ b/service/s3/snapshot/api_op_GetBucketMetricsConfiguration.go.snap
@@ -44,5 +44,6 @@ GetBucketMetricsConfiguration
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_GetBucketNotificationConfiguration.go.snap
+++ b/service/s3/snapshot/api_op_GetBucketNotificationConfiguration.go.snap
@@ -44,6 +44,5 @@ GetBucketNotificationConfiguration
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
-		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_GetBucketNotificationConfiguration.go.snap
+++ b/service/s3/snapshot/api_op_GetBucketNotificationConfiguration.go.snap
@@ -44,5 +44,6 @@ GetBucketNotificationConfiguration
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_GetBucketOwnershipControls.go.snap
+++ b/service/s3/snapshot/api_op_GetBucketOwnershipControls.go.snap
@@ -44,5 +44,6 @@ GetBucketOwnershipControls
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_GetBucketOwnershipControls.go.snap
+++ b/service/s3/snapshot/api_op_GetBucketOwnershipControls.go.snap
@@ -44,6 +44,5 @@ GetBucketOwnershipControls
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
-		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_GetBucketPolicyStatus.go.snap
+++ b/service/s3/snapshot/api_op_GetBucketPolicyStatus.go.snap
@@ -44,5 +44,6 @@ GetBucketPolicyStatus
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_GetBucketPolicyStatus.go.snap
+++ b/service/s3/snapshot/api_op_GetBucketPolicyStatus.go.snap
@@ -44,6 +44,5 @@ GetBucketPolicyStatus
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
-		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_GetBucketReplication.go.snap
+++ b/service/s3/snapshot/api_op_GetBucketReplication.go.snap
@@ -44,5 +44,6 @@ GetBucketReplication
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_GetBucketReplication.go.snap
+++ b/service/s3/snapshot/api_op_GetBucketReplication.go.snap
@@ -44,6 +44,5 @@ GetBucketReplication
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
-		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_GetBucketRequestPayment.go.snap
+++ b/service/s3/snapshot/api_op_GetBucketRequestPayment.go.snap
@@ -44,6 +44,5 @@ GetBucketRequestPayment
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
-		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_GetBucketRequestPayment.go.snap
+++ b/service/s3/snapshot/api_op_GetBucketRequestPayment.go.snap
@@ -44,5 +44,6 @@ GetBucketRequestPayment
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_GetBucketTagging.go.snap
+++ b/service/s3/snapshot/api_op_GetBucketTagging.go.snap
@@ -44,5 +44,6 @@ GetBucketTagging
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_GetBucketVersioning.go.snap
+++ b/service/s3/snapshot/api_op_GetBucketVersioning.go.snap
@@ -44,6 +44,5 @@ GetBucketVersioning
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
-		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_GetBucketVersioning.go.snap
+++ b/service/s3/snapshot/api_op_GetBucketVersioning.go.snap
@@ -44,5 +44,6 @@ GetBucketVersioning
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_GetBucketWebsite.go.snap
+++ b/service/s3/snapshot/api_op_GetBucketWebsite.go.snap
@@ -44,5 +44,6 @@ GetBucketWebsite
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_GetBucketWebsite.go.snap
+++ b/service/s3/snapshot/api_op_GetBucketWebsite.go.snap
@@ -44,6 +44,5 @@ GetBucketWebsite
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
-		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_GetObjectAcl.go.snap
+++ b/service/s3/snapshot/api_op_GetObjectAcl.go.snap
@@ -44,5 +44,6 @@ GetObjectAcl
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_GetObjectAttributes.go.snap
+++ b/service/s3/snapshot/api_op_GetObjectAttributes.go.snap
@@ -44,5 +44,6 @@ GetObjectAttributes
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_GetObjectLegalHold.go.snap
+++ b/service/s3/snapshot/api_op_GetObjectLegalHold.go.snap
@@ -44,5 +44,6 @@ GetObjectLegalHold
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_GetObjectLockConfiguration.go.snap
+++ b/service/s3/snapshot/api_op_GetObjectLockConfiguration.go.snap
@@ -44,6 +44,5 @@ GetObjectLockConfiguration
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
-		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_GetObjectLockConfiguration.go.snap
+++ b/service/s3/snapshot/api_op_GetObjectLockConfiguration.go.snap
@@ -44,5 +44,6 @@ GetObjectLockConfiguration
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_GetObjectRetention.go.snap
+++ b/service/s3/snapshot/api_op_GetObjectRetention.go.snap
@@ -44,5 +44,6 @@ GetObjectRetention
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_GetObjectTagging.go.snap
+++ b/service/s3/snapshot/api_op_GetObjectTagging.go.snap
@@ -44,6 +44,5 @@ GetObjectTagging
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
-		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_GetObjectTagging.go.snap
+++ b/service/s3/snapshot/api_op_GetObjectTagging.go.snap
@@ -44,5 +44,6 @@ GetObjectTagging
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_GetPublicAccessBlock.go.snap
+++ b/service/s3/snapshot/api_op_GetPublicAccessBlock.go.snap
@@ -44,5 +44,6 @@ GetPublicAccessBlock
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_HeadBucket.go.snap
+++ b/service/s3/snapshot/api_op_HeadBucket.go.snap
@@ -44,5 +44,6 @@ HeadBucket
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_HeadBucket.go.snap
+++ b/service/s3/snapshot/api_op_HeadBucket.go.snap
@@ -44,6 +44,5 @@ HeadBucket
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
-		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_HeadObject.go.snap
+++ b/service/s3/snapshot/api_op_HeadObject.go.snap
@@ -44,5 +44,6 @@ HeadObject
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_HeadObject.go.snap
+++ b/service/s3/snapshot/api_op_HeadObject.go.snap
@@ -44,6 +44,5 @@ HeadObject
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
-		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_ListBucketAnalyticsConfigurations.go.snap
+++ b/service/s3/snapshot/api_op_ListBucketAnalyticsConfigurations.go.snap
@@ -44,5 +44,6 @@ ListBucketAnalyticsConfigurations
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_ListBucketIntelligentTieringConfigurations.go.snap
+++ b/service/s3/snapshot/api_op_ListBucketIntelligentTieringConfigurations.go.snap
@@ -44,5 +44,6 @@ ListBucketIntelligentTieringConfigurations
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_ListBucketInventoryConfigurations.go.snap
+++ b/service/s3/snapshot/api_op_ListBucketInventoryConfigurations.go.snap
@@ -44,5 +44,6 @@ ListBucketInventoryConfigurations
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_ListBucketMetricsConfigurations.go.snap
+++ b/service/s3/snapshot/api_op_ListBucketMetricsConfigurations.go.snap
@@ -44,5 +44,6 @@ ListBucketMetricsConfigurations
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_ListBuckets.go.snap
+++ b/service/s3/snapshot/api_op_ListBuckets.go.snap
@@ -43,5 +43,6 @@ ListBuckets
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_ListBuckets.go.snap
+++ b/service/s3/snapshot/api_op_ListBuckets.go.snap
@@ -43,6 +43,5 @@ ListBuckets
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
-		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_ListDirectoryBuckets.go.snap
+++ b/service/s3/snapshot/api_op_ListDirectoryBuckets.go.snap
@@ -43,5 +43,6 @@ ListDirectoryBuckets
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_ListDirectoryBuckets.go.snap
+++ b/service/s3/snapshot/api_op_ListDirectoryBuckets.go.snap
@@ -43,6 +43,5 @@ ListDirectoryBuckets
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
-		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_ListMultipartUploads.go.snap
+++ b/service/s3/snapshot/api_op_ListMultipartUploads.go.snap
@@ -44,5 +44,6 @@ ListMultipartUploads
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_ListObjectAnnotations.go.snap
+++ b/service/s3/snapshot/api_op_ListObjectAnnotations.go.snap
@@ -44,5 +44,6 @@ ListObjectAnnotations
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_ListObjectVersions.go.snap
+++ b/service/s3/snapshot/api_op_ListObjectVersions.go.snap
@@ -44,6 +44,5 @@ ListObjectVersions
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
-		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_ListObjectVersions.go.snap
+++ b/service/s3/snapshot/api_op_ListObjectVersions.go.snap
@@ -44,5 +44,6 @@ ListObjectVersions
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_ListObjects.go.snap
+++ b/service/s3/snapshot/api_op_ListObjects.go.snap
@@ -44,6 +44,5 @@ ListObjects
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
-		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_ListObjects.go.snap
+++ b/service/s3/snapshot/api_op_ListObjects.go.snap
@@ -44,5 +44,6 @@ ListObjects
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_ListObjectsV2.go.snap
+++ b/service/s3/snapshot/api_op_ListObjectsV2.go.snap
@@ -44,5 +44,6 @@ ListObjectsV2
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_ListObjectsV2.go.snap
+++ b/service/s3/snapshot/api_op_ListObjectsV2.go.snap
@@ -44,6 +44,5 @@ ListObjectsV2
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
-		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_ListParts.go.snap
+++ b/service/s3/snapshot/api_op_ListParts.go.snap
@@ -44,5 +44,6 @@ ListParts
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_PutBucketAbac.go.snap
+++ b/service/s3/snapshot/api_op_PutBucketAbac.go.snap
@@ -47,5 +47,6 @@ PutBucketAbac
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_PutBucketAccelerateConfiguration.go.snap
+++ b/service/s3/snapshot/api_op_PutBucketAccelerateConfiguration.go.snap
@@ -47,5 +47,6 @@ PutBucketAccelerateConfiguration
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_PutBucketAcl.go.snap
+++ b/service/s3/snapshot/api_op_PutBucketAcl.go.snap
@@ -48,6 +48,5 @@ PutBucketAcl
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
-		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_PutBucketAcl.go.snap
+++ b/service/s3/snapshot/api_op_PutBucketAcl.go.snap
@@ -48,5 +48,6 @@ PutBucketAcl
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_PutBucketAnalyticsConfiguration.go.snap
+++ b/service/s3/snapshot/api_op_PutBucketAnalyticsConfiguration.go.snap
@@ -44,5 +44,6 @@ PutBucketAnalyticsConfiguration
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_PutBucketAnalyticsConfiguration.go.snap
+++ b/service/s3/snapshot/api_op_PutBucketAnalyticsConfiguration.go.snap
@@ -44,6 +44,5 @@ PutBucketAnalyticsConfiguration
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
-		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_PutBucketCors.go.snap
+++ b/service/s3/snapshot/api_op_PutBucketCors.go.snap
@@ -48,5 +48,6 @@ PutBucketCors
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_PutBucketEncryption.go.snap
+++ b/service/s3/snapshot/api_op_PutBucketEncryption.go.snap
@@ -48,5 +48,6 @@ PutBucketEncryption
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_PutBucketEncryption.go.snap
+++ b/service/s3/snapshot/api_op_PutBucketEncryption.go.snap
@@ -48,6 +48,5 @@ PutBucketEncryption
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
-		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_PutBucketIntelligentTieringConfiguration.go.snap
+++ b/service/s3/snapshot/api_op_PutBucketIntelligentTieringConfiguration.go.snap
@@ -44,5 +44,6 @@ PutBucketIntelligentTieringConfiguration
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_PutBucketInventoryConfiguration.go.snap
+++ b/service/s3/snapshot/api_op_PutBucketInventoryConfiguration.go.snap
@@ -44,5 +44,6 @@ PutBucketInventoryConfiguration
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_PutBucketLifecycleConfiguration.go.snap
+++ b/service/s3/snapshot/api_op_PutBucketLifecycleConfiguration.go.snap
@@ -48,5 +48,6 @@ PutBucketLifecycleConfiguration
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_PutBucketLogging.go.snap
+++ b/service/s3/snapshot/api_op_PutBucketLogging.go.snap
@@ -48,5 +48,6 @@ PutBucketLogging
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_PutBucketMetricsConfiguration.go.snap
+++ b/service/s3/snapshot/api_op_PutBucketMetricsConfiguration.go.snap
@@ -44,5 +44,6 @@ PutBucketMetricsConfiguration
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_PutBucketNotificationConfiguration.go.snap
+++ b/service/s3/snapshot/api_op_PutBucketNotificationConfiguration.go.snap
@@ -44,5 +44,6 @@ PutBucketNotificationConfiguration
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_PutBucketOwnershipControls.go.snap
+++ b/service/s3/snapshot/api_op_PutBucketOwnershipControls.go.snap
@@ -48,5 +48,6 @@ PutBucketOwnershipControls
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_PutBucketPolicy.go.snap
+++ b/service/s3/snapshot/api_op_PutBucketPolicy.go.snap
@@ -48,5 +48,6 @@ PutBucketPolicy
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_PutBucketPolicy.go.snap
+++ b/service/s3/snapshot/api_op_PutBucketPolicy.go.snap
@@ -48,6 +48,5 @@ PutBucketPolicy
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
-		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_PutBucketReplication.go.snap
+++ b/service/s3/snapshot/api_op_PutBucketReplication.go.snap
@@ -48,5 +48,6 @@ PutBucketReplication
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_PutBucketRequestPayment.go.snap
+++ b/service/s3/snapshot/api_op_PutBucketRequestPayment.go.snap
@@ -48,5 +48,6 @@ PutBucketRequestPayment
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_PutBucketTagging.go.snap
+++ b/service/s3/snapshot/api_op_PutBucketTagging.go.snap
@@ -48,5 +48,6 @@ PutBucketTagging
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_PutBucketVersioning.go.snap
+++ b/service/s3/snapshot/api_op_PutBucketVersioning.go.snap
@@ -48,5 +48,6 @@ PutBucketVersioning
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_PutBucketWebsite.go.snap
+++ b/service/s3/snapshot/api_op_PutBucketWebsite.go.snap
@@ -48,5 +48,6 @@ PutBucketWebsite
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_PutObject.go.snap
+++ b/service/s3/snapshot/api_op_PutObject.go.snap
@@ -49,5 +49,6 @@ PutObject
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_PutObject.go.snap
+++ b/service/s3/snapshot/api_op_PutObject.go.snap
@@ -49,6 +49,5 @@ PutObject
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
-		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_PutObjectAcl.go.snap
+++ b/service/s3/snapshot/api_op_PutObjectAcl.go.snap
@@ -48,5 +48,6 @@ PutObjectAcl
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_PutObjectAcl.go.snap
+++ b/service/s3/snapshot/api_op_PutObjectAcl.go.snap
@@ -48,6 +48,5 @@ PutObjectAcl
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
-		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_PutObjectAnnotation.go.snap
+++ b/service/s3/snapshot/api_op_PutObjectAnnotation.go.snap
@@ -48,5 +48,6 @@ PutObjectAnnotation
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_PutObjectLegalHold.go.snap
+++ b/service/s3/snapshot/api_op_PutObjectLegalHold.go.snap
@@ -48,5 +48,6 @@ PutObjectLegalHold
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_PutObjectLockConfiguration.go.snap
+++ b/service/s3/snapshot/api_op_PutObjectLockConfiguration.go.snap
@@ -48,5 +48,6 @@ PutObjectLockConfiguration
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_PutObjectRetention.go.snap
+++ b/service/s3/snapshot/api_op_PutObjectRetention.go.snap
@@ -48,6 +48,5 @@ PutObjectRetention
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
-		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_PutObjectRetention.go.snap
+++ b/service/s3/snapshot/api_op_PutObjectRetention.go.snap
@@ -48,5 +48,6 @@ PutObjectRetention
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_PutObjectTagging.go.snap
+++ b/service/s3/snapshot/api_op_PutObjectTagging.go.snap
@@ -48,6 +48,5 @@ PutObjectTagging
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
-		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_PutObjectTagging.go.snap
+++ b/service/s3/snapshot/api_op_PutObjectTagging.go.snap
@@ -48,5 +48,6 @@ PutObjectTagging
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_PutPublicAccessBlock.go.snap
+++ b/service/s3/snapshot/api_op_PutPublicAccessBlock.go.snap
@@ -48,5 +48,6 @@ PutPublicAccessBlock
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_RenameObject.go.snap
+++ b/service/s3/snapshot/api_op_RenameObject.go.snap
@@ -45,5 +45,6 @@ RenameObject
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_RestoreObject.go.snap
+++ b/service/s3/snapshot/api_op_RestoreObject.go.snap
@@ -47,5 +47,6 @@ RestoreObject
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_UpdateBucketMetadataAnnotationTableConfiguration.go.snap
+++ b/service/s3/snapshot/api_op_UpdateBucketMetadataAnnotationTableConfiguration.go.snap
@@ -48,5 +48,6 @@ UpdateBucketMetadataAnnotationTableConfiguration
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_UpdateBucketMetadataInventoryTableConfiguration.go.snap
+++ b/service/s3/snapshot/api_op_UpdateBucketMetadataInventoryTableConfiguration.go.snap
@@ -48,5 +48,6 @@ UpdateBucketMetadataInventoryTableConfiguration
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_UpdateBucketMetadataJournalTableConfiguration.go.snap
+++ b/service/s3/snapshot/api_op_UpdateBucketMetadataJournalTableConfiguration.go.snap
@@ -48,5 +48,6 @@ UpdateBucketMetadataJournalTableConfiguration
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_UpdateObjectEncryption.go.snap
+++ b/service/s3/snapshot/api_op_UpdateObjectEncryption.go.snap
@@ -48,5 +48,6 @@ UpdateObjectEncryption
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_UploadPart.go.snap
+++ b/service/s3/snapshot/api_op_UploadPart.go.snap
@@ -49,5 +49,6 @@ UploadPart
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_UploadPart.go.snap
+++ b/service/s3/snapshot/api_op_UploadPart.go.snap
@@ -49,6 +49,5 @@ UploadPart
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
-		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger

--- a/service/s3/snapshot/api_op_WriteGetObjectResponse.go.snap
+++ b/service/s3/snapshot/api_op_WriteGetObjectResponse.go.snap
@@ -45,5 +45,6 @@ WriteGetObjectResponse
 		ResponseErrorWrapper
 		S3MetadataRetriever
 		OperationDeserializer
+		S3:ProcessResponseFor200Error
 		RecordResponseTiming
 		RequestResponseLogger


### PR DESCRIPTION
 Expand S3 200-with-error handling to all qualifying operations

## Motivation
We have a customization to identify when s3 returns a response with a 200 status code but it actually contains an error. We in Go had it just for a handful of operation, but internal specification mentions that this can happen in way more places. Changed our codegen to expand on which operations we add this check.

## Changes

**Codegen (`S3ErrorWith200Status.java`):** Replaced the hardcoded 3-operation
allowlist with the Smithy selector from the internal specification. The
middleware is now registered on all S3 operations whose output does NOT contain
an `@httpPayload` member targeting a `@streaming` shape or a `string`. This
matches the selector:

```
operation :not(:test(
    -[output]-> structure
    > member[trait|httpPayload]
    > :is([trait|streaming], string)))
```

**Runtime (`handle_200_error.go`):** Updated the empty-body case to pass through
instead of returning a deserialization error. Per the specification's "Response
parsing runtime safety" requirement, the SDK MUST NOT fail the request if parsing
fails — it must continue regular response handling. This was necessary because
many S3 operations (DELETE operations, WriteGetObjectResponse, etc.) can
legitimately return empty 200 responses.

**Test (`handle_200_error_test.go`):** Updated the `200NoResponse` test case to
expect success on an empty body, matching the new behavior.

## Backwards compatibility

This change **may surface errors that were previously silently swallowed**. For
operations beyond the original 3, a 200 response containing an `<Error>` XML
root element will now be treated as an error and retried (if retryable) rather
than being deserialized as a successful response. In practice:

- **InternalError / SlowDown**: These will now be retried automatically on all
  S3 operations. Previously, only CopyObject, CompleteMultipartUpload, and
  UploadPartCopy retried them. This is a correctness improvement — customers
  were silently receiving error bodies treated as success on other operations.
- **Empty 200 responses**: No longer cause a deserialization error. Operations
  that return empty bodies (e.g. DELETE, PUT with no response content) are
  unaffected.
- **Non-XML 200 responses**: Operations with streaming or string payloads
  (GetObject, SelectObjectContent, GetBucketPolicy) are excluded by the
  codegen filter, so their behavior is unchanged.

The net effect is that customers who previously received silent data corruption
(error XML deserialized as a successful response) will now correctly receive an
error or benefit from automatic retry.