### PR TITLE
Migrate serde2 kitchensink eventstream tests to smithy-go/eventstream

### DIFF
--- a/internal/kitchensinktest/eventstream_test.go
+++ b/internal/kitchensinktest/eventstream_test.go
@@ -9,8 +9,7 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream"
-	"github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream/eventstreamapi"
+	"github.com/aws/smithy-go/eventstream"
 	smithyendpoints "github.com/aws/smithy-go/endpoints"
 	"github.com/aws/smithy-go/middleware"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
@@ -61,15 +60,15 @@ func TestSubscribeEvents_Close(t *testing.T) {
 	payload := encodeEventStream(t, []eventstream.Message{
 		{
 			Headers: eventstream.Headers{
-				{Name: eventstreamapi.MessageTypeHeader, Value: eventstream.StringValue(eventstreamapi.EventMessageType)},
-				{Name: eventstreamapi.EventTypeHeader, Value: eventstream.StringValue("initial-response")},
+				{Name: eventstream.MessageTypeHeader, Value: eventstream.StringValue(eventstream.EventMessageType)},
+				{Name: eventstream.EventTypeHeader, Value: eventstream.StringValue("initial-response")},
 			},
 			Payload: []byte(`{}`),
 		},
 		{
 			Headers: eventstream.Headers{
-				{Name: eventstreamapi.MessageTypeHeader, Value: eventstream.StringValue(eventstreamapi.EventMessageType)},
-				{Name: eventstreamapi.EventTypeHeader, Value: eventstream.StringValue("message")},
+				{Name: eventstream.MessageTypeHeader, Value: eventstream.StringValue(eventstream.EventMessageType)},
+				{Name: eventstream.EventTypeHeader, Value: eventstream.StringValue("message")},
 			},
 			Payload: []byte(`{"body":"hello"}`),
 		},

--- a/internal/kitchensinktest/go.mod
+++ b/internal/kitchensinktest/go.mod
@@ -4,7 +4,6 @@ go 1.24
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.43.0
-	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.14
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.31
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.31
 	github.com/aws/smithy-go v1.27.5

--- a/internal/kitchensinktest/go.sum
+++ b/internal/kitchensinktest/go.sum
@@ -1,4 +1,2 @@
-github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.14 h1:3IZY0XAJquT3aHzbkHfPzy4ACPcEjVG0x87KOwtpqGY=
-github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.14/go.mod h1:zwM6veDkhGgQFqkBy+uT28AAYpLu+uFMlPl+rCg/73E=
 github.com/aws/smithy-go v1.27.5 h1:d1ro7KpYOYwP6m73YFa+Kc/A130VsAdX68SpsJwARMM=
 github.com/aws/smithy-go v1.27.5/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=

--- a/internal/kitchensinktestrestjson/eventstream_test.go
+++ b/internal/kitchensinktestrestjson/eventstream_test.go
@@ -7,8 +7,7 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream"
-	"github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream/eventstreamapi"
+	"github.com/aws/smithy-go/eventstream"
 	smithyendpoints "github.com/aws/smithy-go/endpoints"
 	"github.com/aws/smithy-go/middleware"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
@@ -44,15 +43,15 @@ func TestSubscribeEvents_Close(t *testing.T) {
 	payload := encodeEventStream(t, []eventstream.Message{
 		{
 			Headers: eventstream.Headers{
-				{Name: eventstreamapi.MessageTypeHeader, Value: eventstream.StringValue(eventstreamapi.EventMessageType)},
-				{Name: eventstreamapi.EventTypeHeader, Value: eventstream.StringValue("initial-response")},
+				{Name: eventstream.MessageTypeHeader, Value: eventstream.StringValue(eventstream.EventMessageType)},
+				{Name: eventstream.EventTypeHeader, Value: eventstream.StringValue("initial-response")},
 			},
 			Payload: []byte(`{}`),
 		},
 		{
 			Headers: eventstream.Headers{
-				{Name: eventstreamapi.MessageTypeHeader, Value: eventstream.StringValue(eventstreamapi.EventMessageType)},
-				{Name: eventstreamapi.EventTypeHeader, Value: eventstream.StringValue("message")},
+				{Name: eventstream.MessageTypeHeader, Value: eventstream.StringValue(eventstream.EventMessageType)},
+				{Name: eventstream.EventTypeHeader, Value: eventstream.StringValue("message")},
 			},
 			Payload: []byte(`{"body":"hello"}`),
 		},

--- a/internal/kitchensinktestrestjson/go.mod
+++ b/internal/kitchensinktestrestjson/go.mod
@@ -4,7 +4,6 @@ go 1.24
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.43.0
-	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.14
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.31
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.31
 	github.com/aws/smithy-go v1.27.5

--- a/internal/kitchensinktestrestjson/go.sum
+++ b/internal/kitchensinktestrestjson/go.sum
@@ -1,4 +1,2 @@
-github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.14 h1:3IZY0XAJquT3aHzbkHfPzy4ACPcEjVG0x87KOwtpqGY=
-github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.14/go.mod h1:zwM6veDkhGgQFqkBy+uT28AAYpLu+uFMlPl+rCg/73E=
 github.com/aws/smithy-go v1.27.5 h1:d1ro7KpYOYwP6m73YFa+Kc/A130VsAdX68SpsJwARMM=
 github.com/aws/smithy-go v1.27.5/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=


### PR DESCRIPTION
  ## Summary
  The `eventstream_test.go` files in the serde2 `internal/kitchensinktest` and `internal/kitchensinktestrestjson` modules imported the legacy `github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream` (+ `/eventstreamapi`) package, while the co-located generated `eventstream.go` already uses `github.com/aws/smithy-go/eventstream`.
  Because the generated code no longer references the legacy package, the dependency was only pulled in by the hand-written test, so it had a `require` line but no in-repo `replace` directive. When the smithy-go upgrade re-resolved every module's versions, `go mod tidy` in the clean preview build bumped the unpinned require to an unpublished pseudo-version whose `go.sum` entry was missing, breaking the build:
  ```
  missing go.sum entry for module providing package
  github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream
  ```
  ## Fix
  Migrate the tests to `smithy-go/eventstream` so they match the generated code. The APIs are identical; only the message-type constants moved from the `eventstreamapi` subpackage into the `eventstream` package itself. `go mod tidy` then drops the stale require line from `go.mod`/`go.sum`, removing the dependency that could be bumped. Legacy kitchensink modules are left unchanged: their generated code still uses the legacy package and their `go.mod` carries a local `replace` directive, so they remain self-consistent.
  ## Testing
  - `go test ./...` passes in both `internal/kitchensinktest` and `internal/kitchensinktestrestjson`.
  - Reproduced against the actual failed preview build artifact: on the original snapshot `go mod tidy` fails with `unknown revision aws/protocol/eventstream/v1.7.15-zeta...` (the smithy-go bump had re-resolved the unpinned require to an unpublished pseudo-version). After applying this change, `aws/protocol/eventstream` drops out of `go.mod`/`go.sum` entirely and `go mod verify` reports `all modules verified`.