### PR TITLE
Set FIPS-approved TLS curve preferences when the FIPS module is active

### DIFF
--- a/aws/transport/http/client.go
+++ b/aws/transport/http/client.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"context"
+	"crypto/fips140"
 	"crypto/tls"
 	"net"
 	"net/http"
@@ -27,6 +28,19 @@ var (
 
 	// Default to TLS 1.2 for all HTTPS requests.
 	DefaultHTTPTransportTLSMinVersion uint16 = tls.VersionTLS12
+
+	// DefaultHTTPTransportTLSCurvePreferencesFIPS is the elliptic curve preference
+	// list applied to the default transport when the FIPS 140-3 module is active.
+	//
+	// Go's default preferences lead with X25519, which crypto/ecdh rejects under
+	// GODEBUG=fips140=only, failing every TLS handshake the SDK attempts. Only the
+	// NIST curves are FIPS-approved, so restricting to them keeps the default
+	// client usable in FIPS deployments.
+	DefaultHTTPTransportTLSCurvePreferencesFIPS = []tls.CurveID{
+		tls.CurveP256,
+		tls.CurveP384,
+		tls.CurveP521,
+	}
 )
 
 // Timeouts for net.Dialer's network connection.
@@ -178,6 +192,16 @@ func defaultDialer() *net.Dialer {
 	}
 }
 
+// defaultTLSCurvePreferences returns the curve preferences for the default
+// transport. Outside FIPS mode it returns nil so Go's own defaults apply,
+// preserving X25519 and the post-quantum X25519MLKEM768 hybrid.
+func defaultTLSCurvePreferences(fipsEnabled bool) []tls.CurveID {
+	if !fipsEnabled {
+		return nil
+	}
+	return DefaultHTTPTransportTLSCurvePreferencesFIPS
+}
+
 func defaultHTTPTransport() *http.Transport {
 	dialer := defaultDialer()
 
@@ -192,7 +216,8 @@ func defaultHTTPTransport() *http.Transport {
 		ExpectContinueTimeout: DefaultHTTPTransportExpectContinueTimeout,
 		ForceAttemptHTTP2:     true,
 		TLSClientConfig: &tls.Config{
-			MinVersion: DefaultHTTPTransportTLSMinVersion,
+			MinVersion:       DefaultHTTPTransportTLSMinVersion,
+			CurvePreferences: defaultTLSCurvePreferences(fips140.Enabled()),
 		},
 	}
 

--- a/aws/transport/http/client_test.go
+++ b/aws/transport/http/client_test.go
@@ -1,6 +1,8 @@
 package http
 
 import (
+	"crypto/fips140"
+	"crypto/tls"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -156,5 +158,70 @@ func TestBuildableClient_KeepsSecurityTokenOnSameHost(t *testing.T) {
 
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("expect 200 code, got %d", resp.StatusCode)
+	}
+}
+
+func TestDefaultTLSCurvePreferences(t *testing.T) {
+	cases := map[string]struct {
+		FIPSEnabled bool
+		Expect      []tls.CurveID
+	}{
+		"fips disabled defers to go defaults": {
+			FIPSEnabled: false,
+			Expect:      nil,
+		},
+		"fips enabled restricts to approved curves": {
+			FIPSEnabled: true,
+			Expect:      []tls.CurveID{tls.CurveP256, tls.CurveP384, tls.CurveP521},
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			curves := defaultTLSCurvePreferences(c.FIPSEnabled)
+
+			if e, a := len(c.Expect), len(curves); e != a {
+				t.Fatalf("expect %v curves, got %v (%v)", e, a, curves)
+			}
+			for i, expect := range c.Expect {
+				if e, a := expect, curves[i]; e != a {
+					t.Errorf("expect curve %v at %v, got %v", e, i, a)
+				}
+			}
+		})
+	}
+}
+
+func TestDefaultTLSCurvePreferences_NoX25519UnderFIPS(t *testing.T) {
+	// X25519 and the X25519MLKEM768 hybrid are not FIPS-approved; crypto/ecdh
+	// rejects them under GODEBUG=fips140=only, which is what broke every
+	// handshake made by the default client.
+	for _, curve := range defaultTLSCurvePreferences(true) {
+		if curve == tls.X25519 || curve == tls.X25519MLKEM768 {
+			t.Errorf("expect no non-approved curve under FIPS, got %v", curve)
+		}
+	}
+}
+
+func TestDefaultHTTPTransport_TLSConfig(t *testing.T) {
+	tr := defaultHTTPTransport()
+
+	if tr.TLSClientConfig == nil {
+		t.Fatal("expect TLS client config, got none")
+	}
+	if e, a := DefaultHTTPTransportTLSMinVersion, tr.TLSClientConfig.MinVersion; e != a {
+		t.Errorf("expect min version %v, got %v", e, a)
+	}
+
+	// The transport must mirror whatever mode the process is actually running in:
+	// untouched preferences normally, NIST-only when the FIPS module is active.
+	expect := defaultTLSCurvePreferences(fips140.Enabled())
+	if e, a := len(expect), len(tr.TLSClientConfig.CurvePreferences); e != a {
+		t.Fatalf("expect %v curves, got %v", e, a)
+	}
+	for i, curve := range expect {
+		if e, a := curve, tr.TLSClientConfig.CurvePreferences[i]; e != a {
+			t.Errorf("expect curve %v at %v, got %v", e, i, a)
+		}
 	}
 }


### PR DESCRIPTION
Fixes #3345

### Problem

Every SDK request fails on Go 1.25+ under `GODEBUG=fips140=only`:

```
crypto/ecdh: use of X25519 is not allowed in FIPS 140-only mode
```

`defaultHTTPTransport()` built its `tls.Config` with only `MinVersion` set, leaving `CurvePreferences` empty so Go's defaults applied. Those lead with X25519, which `crypto/ecdh` rejects outright in FIPS 140-only mode, so the handshake dies before any AWS call is made. Go 1.24 introduced `fips140=only` but did not enforce the X25519 rejection; 1.25 does, which is why this surfaced now.

### Approach

The issue suggested either setting FIPS-safe `CurvePreferences` outright or detecting FIPS at runtime. I went with the second: setting them unconditionally would strip X25519 *and* the Go 1.24+ post-quantum `X25519MLKEM768` hybrid from every SDK user, the overwhelming majority of whom are not in FIPS mode. That is a real downgrade to pay for a FIPS-only bug.

Instead, `defaultTLSCurvePreferences` returns `nil` normally — Go's defaults, completely unchanged — and the NIST curves only when `crypto/fips140.Enabled()` reports the module is active. The module targets `go 1.24`, so `crypto/fips140` is available without build tags.

This also covers `fips140=on`, where X25519 is permitted but not approved; restricting to approved curves there matches FIPS intent rather than leaving a second inconsistent mode.

### Verification

Behavior of the default transport, using a small program that reads `NewBuildableClient().GetTransport().TLSClientConfig` against this branch:

**Before (`origin/main`)**

```
--- normal mode ---
fips140.Enabled() = false
CurvePreferences: [] (Go defaults, includes X25519)
--- GODEBUG=fips140=only ---
fips140.Enabled() = true
CurvePreferences: [] (Go defaults, includes X25519)   <-- handshake fails here
```

**After (this branch)**

```
--- normal mode ---
fips140.Enabled() = false
CurvePreferences: [] (Go defaults, includes X25519)   <-- unchanged
--- GODEBUG=fips140=only ---
fips140.Enabled() = true
CurvePreferences: [P-256 P-384 P-521]
```

The normal-mode line is identical before and after, which is the point: non-FIPS users keep X25519 and the post-quantum hybrid.

Unit tests cover both branches of the selection, assert no non-approved curve can appear under FIPS, and check the transport's own TLS config. They pass in both modes:

```
$ GOFIPS140=latest GODEBUG=fips140=only go test -v -run 'TestDefaultTLSCurvePreferences|TestDefaultHTTPTransport_TLSConfig' ./aws/transport/http/
--- PASS: TestDefaultTLSCurvePreferences (0.00s)
    --- PASS: TestDefaultTLSCurvePreferences/fips_enabled_restricts_to_approved_curves (0.00s)
    --- PASS: TestDefaultTLSCurvePreferences/fips_disabled_defers_to_go_defaults (0.00s)
--- PASS: TestDefaultTLSCurvePreferences_NoX25519UnderFIPS (0.00s)
--- PASS: TestDefaultHTTPTransport_TLSConfig (0.00s)
ok  	github.com/aws/aws-sdk-go-v2/aws/transport/http	0.360s
```

Also clean: `go build ./...`, `go vet ./aws/transport/http/`, `gofmt -l` (no output), and the full `./aws/transport/http/...` package tests.

I did not run the issue's end-to-end STS reproduction, since it needs live AWS credentials against a FIPS endpoint. The transport-level output above isolates the same root cause.

Per CONTRIBUTING, no `.changelog` entry is included.
