### PR TITLE
Checkout smithy-go on PRs at the commit pointed out by SMITHY_GO_CODEGEN_VERSION

### DIFF
--- a/ci-find-smithy-go.sh
+++ b/ci-find-smithy-go.sh
@@ -55,7 +55,8 @@ done
 
 if [ -z "$matched_branch" ]; then
     # default to SMITHY_GO_CODEGEN_VERSION so CI uses the same smithy-go as prod
-    codegen_version=$(cat SMITHY_GO_CODEGEN_VERSION)
+    # strip any trailing whitespace/newlines that editors may add to the file
+    codegen_version=$(tr -d '[:space:]' < SMITHY_GO_CODEGEN_VERSION)
     echo "no matching branch, checking out smithy-go at SMITHY_GO_CODEGEN_VERSION=${codegen_version}"
     git clone "$repository" "$RUNNER_TMPDIR"/smithy-go
     git -C "$RUNNER_TMPDIR"/smithy-go checkout "$codegen_version"

--- a/ci-find-smithy-go.sh
+++ b/ci-find-smithy-go.sh
@@ -54,9 +54,11 @@ while [ -n "$branch" ] && [[ "$branch" == *-* ]]; do
 done
 
 if [ -z "$matched_branch" ]; then
-    # default to main but don't modreplace so we can use release but codegen ci
-    # still works
+    # default to SMITHY_GO_CODEGEN_VERSION so CI uses the same smithy-go as prod
+    codegen_version=$(cat SMITHY_GO_CODEGEN_VERSION)
+    echo "no matching branch, checking out smithy-go at SMITHY_GO_CODEGEN_VERSION=${codegen_version}"
     git clone "$repository" "$RUNNER_TMPDIR"/smithy-go
+    git -C "$RUNNER_TMPDIR"/smithy-go checkout "$codegen_version"
     exit 0
 fi
 


### PR DESCRIPTION
Testing by checking the CI logs

```
no matching branch, checking out smithy-go at SMITHY_GO_CODEGEN_VERSION=7016ea047f6a4ff0d293ff395a9f4fd202223200
```

which is the version we have at https://github.com/aws/aws-sdk-go-v2/blob/main/SMITHY_GO_CODEGEN_VERSION