### PR TITLE
Fix route53 error close body

### DIFF
--- a/.changelog/ec5991a70ed74a5f91b32cfa2296eb80.json
+++ b/.changelog/ec5991a70ed74a5f91b32cfa2296eb80.json
@@ -1,0 +1,8 @@
+{
+    "id": "ec5991a7-0ed7-4a5f-91b3-2cfa2296eb80",
+    "type": "bugfix",
+    "description": "Forward the original response body's `Closer` in Route53 custom error handling instead of wrapping it in `io.NopCloser`, and close the body on the custom error path, to avoid issues with TCP connection reuse.",
+    "modules": [
+        "service/route53"
+    ]
+}

--- a/service/route53/internal/customizations/custom_error_deser.go
+++ b/service/route53/internal/customizations/custom_error_deser.go
@@ -60,12 +60,20 @@ func (m *processResponse) HandleDeserialize(
 		return out, metadata, nil
 	}
 
-	// rewind response body
-	response.Body = io.NopCloser(io.MultiReader(&readBuff, response.Body))
+	// rewind response body, forwarding the original body's Closer so closing it
+	// still closes the underlying transport body (io.NopCloser would drop it).
+	originalBody := response.Body
+	response.Body = &replayReadCloser{
+		Reader: io.MultiReader(&readBuff, originalBody),
+		Closer: originalBody,
+	}
 
 	// if start tag is "InvalidChangeBatch", the error response needs custom unmarshaling.
 	if strings.EqualFold(t.Name.Local, "InvalidChangeBatch") {
-		return out, metadata, route53CustomErrorDeser(&metadata, response)
+		// The caller won't close the response body when we return an error, so close it here.
+		err = route53CustomErrorDeser(&metadata, response)
+		smithyhttp.CloseResponseBody(ctx, response, false, err)
+		return out, metadata, err
 	}
 
 	return out, metadata, err
@@ -90,4 +98,10 @@ func route53CustomErrorDeser(metadata *middleware.Metadata, response *smithyhttp
 		Message:  ptr.String("ChangeBatch errors occurred"),
 		Messages: err.Messages,
 	}
+}
+
+// replayReadCloser pairs a Reader with an independent Closer.
+type replayReadCloser struct {
+	io.Reader
+	io.Closer
 }

--- a/service/route53/internal/customizations/custom_error_deser_test.go
+++ b/service/route53/internal/customizations/custom_error_deser_test.go
@@ -3,6 +3,7 @@ package customizations_test
 import (
 	"context"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -129,4 +130,57 @@ type fakeCredentials struct{}
 
 func (*fakeCredentials) Retrieve(_ context.Context) (aws.Credentials, error) {
 	return aws.Credentials{}, nil
+}
+
+type mockHTTPClient struct {
+	r *http.Response
+}
+
+func (m *mockHTTPClient) Do(*http.Request) (*http.Response, error) {
+	return m.r, nil
+}
+
+// bodyCloseTracker records whether Close was called on the underlying body.
+type bodyCloseTracker struct {
+	io.Reader
+	closed bool
+}
+
+func (b *bodyCloseTracker) Close() error {
+	b.closed = true
+	return nil
+}
+
+// TestResponseBodyClosed verifies the custom error deserialization forwards
+// Close to the original response body.
+func TestResponseBodyClosed(t *testing.T) {
+	cases := map[string]string{
+		"error":   `<InvalidChangeBatch><Messages><Message>oops</Message></Messages></InvalidChangeBatch>`,
+		"success": `<ChangeResourceRecordSetsResponse><ChangeInfo><Id>mockID</Id></ChangeInfo></ChangeResourceRecordSetsResponse>`,
+	}
+
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			status := 200
+			if name == "error" {
+				status = 500
+			}
+			tracked := &bodyCloseTracker{Reader: strings.NewReader(body)}
+			svc := route53.New(route53.Options{
+				Region:      "us-east-1",
+				Credentials: &fakeCredentials{},
+				Retryer:     aws.NopRetryer{},
+				HTTPClient:  &mockHTTPClient{&http.Response{StatusCode: status, Body: tracked}},
+			})
+
+			_, _ = svc.ChangeResourceRecordSets(context.Background(), &route53.ChangeResourceRecordSetsInput{
+				ChangeBatch:  &types.ChangeBatch{Changes: []types.Change{}, Comment: aws.String("mock")},
+				HostedZoneId: aws.String("zone"),
+			})
+
+			if !tracked.closed {
+				t.Error("original response body was not closed")
+			}
+		})
+	}
 }

--- a/service/route53/internal/customizations/custom_error_deser_test.go
+++ b/service/route53/internal/customizations/custom_error_deser_test.go
@@ -152,32 +152,45 @@ func (b *bodyCloseTracker) Close() error {
 }
 
 // TestResponseBodyClosed verifies the custom error deserialization forwards
-// Close to the original response body.
+// Close to the original response body on both the error and success paths.
 func TestResponseBodyClosed(t *testing.T) {
-	cases := map[string]string{
-		"error":   `<InvalidChangeBatch><Messages><Message>oops</Message></Messages></InvalidChangeBatch>`,
-		"success": `<ChangeResourceRecordSetsResponse><ChangeInfo><Id>mockID</Id></ChangeInfo></ChangeResourceRecordSetsResponse>`,
+	cases := map[string]struct {
+		status      int
+		body        string
+		expectError bool
+	}{
+		"error": {
+			status:      500,
+			body:        `<InvalidChangeBatch><Messages><Message>oops</Message></Messages></InvalidChangeBatch>`,
+			expectError: true,
+		},
+		"success": {
+			status: 200,
+			body:   `<ChangeResourceRecordSetsResponse><ChangeInfo><Id>mockID</Id></ChangeInfo></ChangeResourceRecordSetsResponse>`,
+		},
 	}
 
-	for name, body := range cases {
+	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			status := 200
-			if name == "error" {
-				status = 500
-			}
-			tracked := &bodyCloseTracker{Reader: strings.NewReader(body)}
+			tracked := &bodyCloseTracker{Reader: strings.NewReader(c.body)}
 			svc := route53.New(route53.Options{
 				Region:      "us-east-1",
 				Credentials: &fakeCredentials{},
 				Retryer:     aws.NopRetryer{},
-				HTTPClient:  &mockHTTPClient{&http.Response{StatusCode: status, Body: tracked}},
+				HTTPClient:  &mockHTTPClient{&http.Response{StatusCode: c.status, Body: tracked}},
 			})
 
-			_, _ = svc.ChangeResourceRecordSets(context.Background(), &route53.ChangeResourceRecordSetsInput{
+			_, err := svc.ChangeResourceRecordSets(context.Background(), &route53.ChangeResourceRecordSetsInput{
 				ChangeBatch:  &types.ChangeBatch{Changes: []types.Change{}, Comment: aws.String("mock")},
 				HostedZoneId: aws.String("zone"),
 			})
 
+			if c.expectError && err == nil {
+				t.Error("expected an error, got none")
+			}
+			if !c.expectError && err != nil {
+				t.Errorf("expected no error, got %v", err)
+			}
 			if !tracked.closed {
 				t.Error("original response body was not closed")
 			}


### PR DESCRIPTION
  ## Description
  
  The Route53 custom error deserialization middleware (`custom_error_deser.go`) leaked the HTTP connection on the `InvalidChangeBatch` error path.

  Two issues:

  1. **Dropped Closer**: the middleware rewinds the response body with `io.NopCloser(io.MultiReader(...))`, whose `Close` is a no-op — so closing the response body never reached the underlying transport body.

  2. **Skipped close (Route53-specific)**: when the root element is `InvalidChangeBatch`, this middleware deserializes it into an error and returns it. When a deserialize middleware returns a non-nil error, the caller forwards it up without closing the response body — the convention being that an error path either has no reusable body (e.g. a transport failure) or the returning layer has already cleaned it up. Route53 returned an error here without closing the body, so on this path the connection was neither drained nor released.

  This is the same class of bug fixed for S3 in #3517, but Route53 additionally requires the explicit close because it returns an error (S3 only rewrites the status code and returns `nil`).

  ## Fix

  - Forward the original body's `Closer` via a small `replayReadCloser` (same pattern as the S3 fix) so closing the response body reaches the transport body.

  - Explicitly call `CloseResponseBody` on the `InvalidChangeBatch` path, after custom error deserialization has read the body, so the connection is drained and released.

  ## Testing

  Added `TestResponseBodyClosed`, which asserts the original response body is closed on both the error and success paths. Existing `TestCustomErrorDeserialization` continues to pass.


