### PR TITLE
Fix tmv1 uploadretry flaky test

### DIFF
--- a/.changelog/4b16569ef01a40199ad816cb83fdd86c.json
+++ b/.changelog/4b16569ef01a40199ad816cb83fdd86c.json
@@ -1,0 +1,8 @@
+{
+    "id": "4b16569e-f01a-4019-9ad8-16cb83fdd86c",
+    "type": "bugfix",
+    "description": "Fix flaky test from feature/s3/manager upload retry",
+    "modules": [
+        "feature/s3/manager"
+    ]
+}

--- a/feature/s3/manager/upload_test.go
+++ b/feature/s3/manager/upload_test.go
@@ -5,8 +5,8 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
-	"net/http/httptest"
 	"os"
 	"reflect"
 	"regexp"
@@ -969,19 +969,6 @@ func createTempFile(t *testing.T, size int64) (*os.File, func(*testing.T), error
 		nil
 }
 
-func buildFailHandlers(tb testing.TB, parts, retry int) []http.Handler {
-	handlers := make([]http.Handler, parts)
-	for i := range handlers {
-		handlers[i] = &failPartHandler{
-			tb:             tb,
-			failsRemaining: retry,
-			successHandler: successPartHandler{tb: tb},
-		}
-	}
-
-	return handlers
-}
-
 func TestUploadRetry(t *testing.T) {
 	const numParts, retries = 3, 10
 
@@ -992,26 +979,16 @@ func TestUploadRetry(t *testing.T) {
 	defer testFileCleanup(t)
 
 	cases := map[string]struct {
-		Body         io.Reader
-		PartHandlers func(testing.TB) []http.Handler
+		Body io.Reader
 	}{
 		"bytes.Buffer": {
 			Body: bytes.NewBuffer(make([]byte, manager.DefaultUploadPartSize*numParts)),
-			PartHandlers: func(tb testing.TB) []http.Handler {
-				return buildFailHandlers(tb, numParts, retries)
-			},
 		},
 		"bytes.Reader": {
 			Body: bytes.NewReader(make([]byte, manager.DefaultUploadPartSize*numParts)),
-			PartHandlers: func(tb testing.TB) []http.Handler {
-				return buildFailHandlers(tb, numParts, retries)
-			},
 		},
 		"os.File": {
 			Body: testFile,
-			PartHandlers: func(tb testing.TB) []http.Handler {
-				return buildFailHandlers(tb, numParts, retries)
-			},
 		},
 	}
 
@@ -1020,17 +997,16 @@ func TestUploadRetry(t *testing.T) {
 			restoreSleep := sdk.TestingUseNopSleep()
 			defer restoreSleep()
 
-			mux := newMockS3UploadServer(t, c.PartHandlers(t))
-			server := httptest.NewServer(mux)
-			defer server.Close()
-
+			failsLeft := make([]int, numParts)
+			for i := range failsLeft {
+				failsLeft[i] = retries
+			}
 			client := s3.New(s3.Options{
-				EndpointResolver: s3testing.EndpointResolverFunc(func(region string, options s3.EndpointResolverOptions) (aws.Endpoint, error) {
-					return aws.Endpoint{
-						URL: server.URL,
-					}, nil
-				}),
+				Region:       "us-west-2",
 				UsePathStyle: true,
+				HTTPClient: &retryHTTPClient{
+					failsLeft: failsLeft,
+				},
 				Retryer: retry.NewStandard(func(o *retry.StandardOptions) {
 					o.MaxAttempts = retries + 1
 				}),
@@ -1248,151 +1224,75 @@ func TestUploadRequestChecksumCalculation(t *testing.T) {
 	}
 }
 
-type mockS3UploadServer struct {
-	*http.ServeMux
-
-	tb          testing.TB
-	partHandler []http.Handler
+type retryHTTPClient struct {
+	failsLeft []int
 }
 
-func newMockS3UploadServer(tb testing.TB, partHandler []http.Handler) *mockS3UploadServer {
-	s := &mockS3UploadServer{
-		ServeMux:    http.NewServeMux(),
-		partHandler: partHandler,
-		tb:          tb,
-	}
-
-	s.HandleFunc("/", s.handleRequest)
-
-	return s
-}
-
-func (s mockS3UploadServer) handleRequest(w http.ResponseWriter, r *http.Request) {
-	defer func() {
-		closeErr := r.Body.Close()
-		if closeErr != nil {
-			failRequest(w, 0, "BodyCloseError",
-				fmt.Sprintf("request body close error: %v", closeErr))
-		}
-	}()
-
+func (c *retryHTTPClient) Do(r *http.Request) (*http.Response, error) {
 	_, hasUploads := r.URL.Query()["uploads"]
-
 	switch {
 	case r.Method == "POST" && hasUploads:
-		// CreateMultipartUpload
-		w.Header().Set("Content-Length", strconv.Itoa(len(createUploadResp)))
-		w.Write([]byte(createUploadResp))
-
+		// CreateMultipartUpload req
+		return &http.Response{
+			StatusCode: 200,
+			Header:     http.Header{"Content-Length": {strconv.Itoa(len(createUploadResp))}},
+			Body:       io.NopCloser(bytes.NewReader([]byte(createUploadResp))),
+		}, nil
 	case r.Method == "PUT":
-		// UploadPart
-		partNumStr := r.URL.Query().Get("partNumber")
-		id, err := strconv.Atoi(partNumStr)
+		defer func() {
+			if err := r.Body.Close(); err != nil {
+				log.Printf("failed to close request body: %q", err)
+			}
+		}()
+		partStr := r.URL.Query().Get("partNumber")
+		part, err := strconv.ParseInt(partStr, 10, 64)
 		if err != nil {
-			failRequest(w, 400, "BadRequest",
-				fmt.Sprintf("unable to parse partNumber, %q, %v",
-					partNumStr, err))
-			return
+			return &http.Response{StatusCode: 400, Status: "BadRequest"}, fmt.Errorf("unable to parse partNumber, %q, %v", partStr, err)
 		}
-		id--
-		if id < 0 || id >= len(s.partHandler) {
-			failRequest(w, 400, "BadRequest",
-				fmt.Sprintf("invalid partNumber %v", id))
-			return
+		if part <= 0 || part > int64(len(c.failsLeft)) {
+			return &http.Response{StatusCode: 400, Status: "BadRequest"}, fmt.Errorf("invalid partNumber %v", part)
 		}
-		s.partHandler[id].ServeHTTP(w, r)
 
+		n, _ := io.Copy(io.Discard, r.Body)
+		if c.failsLeft[part-1] == 0 {
+			if e, a := r.ContentLength, n; e != a {
+				errBody := fmt.Sprintf("content length mismatch, expect %d, got %d", e, a)
+				return &http.Response{
+					StatusCode: 400,
+					Status:     "InternalException",
+					Header:     http.Header{"Content-Length": {strconv.Itoa(len(errBody))}},
+					Body:       io.NopCloser(strings.NewReader(errBody)),
+				}, nil
+			}
+			return &http.Response{
+				StatusCode: 200,
+				Header:     http.Header{"Content-Length": []string{strconv.Itoa(len(uploadPartResp))}},
+				Body:       io.NopCloser(bytes.NewReader([]byte(uploadPartResp))),
+			}, nil
+		}
+		c.failsLeft[part-1]--
+		errBody := fmt.Sprintf("mock error, partNumber %s", partStr)
+		return &http.Response{
+			StatusCode: 500,
+			Status:     "InternalException",
+			Header:     http.Header{"Content-Length": {strconv.Itoa(len(errBody))}},
+			Body:       io.NopCloser(strings.NewReader(errBody)),
+		}, nil
 	case r.Method == "POST":
-		// CompleteMultipartUpload
-		w.Header().Set("Content-Length", strconv.Itoa(len(completeUploadResp)))
-		w.Write([]byte(completeUploadResp))
-
+		// CompleteMultipartUpload req
+		return &http.Response{
+			StatusCode: 200,
+			Header:     http.Header{"Content-Length": []string{strconv.Itoa(len(completeUploadResp))}},
+			Body:       io.NopCloser(bytes.NewReader([]byte(completeUploadResp))),
+		}, nil
 	case r.Method == "DELETE":
-		// AbortMultipartUpload
-		w.Header().Set("Content-Length", strconv.Itoa(len(abortUploadResp)))
-		w.WriteHeader(200)
-		w.Write([]byte(abortUploadResp))
-
-	default:
-		failRequest(w, 400, "BadRequest",
-			fmt.Sprintf("invalid request %v %v", r.Method, r.URL))
+		return &http.Response{
+			StatusCode: 200,
+			Header:     http.Header{"Content-Length": []string{strconv.Itoa(len(abortUploadResp))}},
+			Body:       io.NopCloser(bytes.NewReader([]byte(abortUploadResp))),
+		}, nil
 	}
-}
-
-func failRequest(w http.ResponseWriter, status int, code, msg string) {
-	msg = fmt.Sprintf(baseRequestErrorResp, code, msg)
-	w.Header().Set("Content-Length", strconv.Itoa(len(msg)))
-	w.WriteHeader(status)
-	w.Write([]byte(msg))
-}
-
-type successPartHandler struct {
-	tb testing.TB
-}
-
-func (h successPartHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	defer func() {
-		closeErr := r.Body.Close()
-		if closeErr != nil {
-			failRequest(w, 0, "BodyCloseError",
-				fmt.Sprintf("request body close error: %v", closeErr))
-		}
-	}()
-
-	n, err := io.Copy(io.Discard, r.Body)
-	if err != nil {
-		failRequest(w, 400, "BadRequest",
-			fmt.Sprintf("failed to read body, %v", err))
-		return
-	}
-
-	contLenStr := r.Header.Get("Content-Length")
-	expectLen, err := strconv.ParseInt(contLenStr, 10, 64)
-	if err != nil {
-		h.tb.Logf("expect content-length, got %q, %v", contLenStr, err)
-		failRequest(w, 400, "BadRequest",
-			fmt.Sprintf("unable to get content-length %v", err))
-		return
-	}
-	if e, a := expectLen, n; e != a {
-		h.tb.Logf("expect %v read, got %v", e, a)
-		failRequest(w, 400, "BadRequest",
-			fmt.Sprintf(
-				"content-length and body do not match, %v, %v", e, a))
-		return
-	}
-
-	w.Header().Set("Content-Length", strconv.Itoa(len(uploadPartResp)))
-	w.Write([]byte(uploadPartResp))
-}
-
-type failPartHandler struct {
-	tb testing.TB
-
-	failsRemaining int
-	successHandler http.Handler
-}
-
-func (h *failPartHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	defer func() {
-		closeErr := r.Body.Close()
-		if closeErr != nil {
-			failRequest(w, 0, "BodyCloseError",
-				fmt.Sprintf("request body close error: %v", closeErr))
-		}
-	}()
-
-	if h.failsRemaining == 0 && h.successHandler != nil {
-		h.successHandler.ServeHTTP(w, r)
-		return
-	}
-
-	io.Copy(io.Discard, r.Body)
-
-	failRequest(w, 500, "InternalException",
-		fmt.Sprintf("mock error, partNumber %v", r.URL.Query().Get("partNumber")))
-
-	h.failsRemaining--
+	return &http.Response{StatusCode: 400, Status: "BadRequest"}, fmt.Errorf("invalid request %v %v", r.Method, r.URL)
 }
 
 type recordedBufferProvider struct {
@@ -1420,12 +1320,6 @@ const createUploadResp = `<CreateMultipartUploadResponse>
 const uploadPartResp = `<UploadPartResponse>
   <ETag>key</ETag>
 </UploadPartResponse>`
-const baseRequestErrorResp = `<batchItemError>
-  <Code>%s</Code>
-  <Message>%s</Message>
-  <RequestId>request-id</RequestId>
-  <HostId>host-id</HostId>
-</batchItemError>`
 
 const completeUploadResp = `<CompleteMultipartUploadResponse>
   <Bucket>bucket</Bucket>


### PR DESCRIPTION
Same to previous transfer manager v2, tm v1 uses mock http server to run the upload retry test. Consequently concurrent 5mb request body upload causes flaky transport layer overload, which leads to CI failure. This pr fixes it in the same way of #3489 to replace unnecessary http server with just mock http client 