### PR TITLE
Make X-Amz-Checksum-Mode appear on query parameters on presigned URLs

### DIFF
--- a/.changelog/eac4e7b76520487a904af6f66f12caa1.json
+++ b/.changelog/eac4e7b76520487a904af6f66f12caa1.json
@@ -1,0 +1,8 @@
+{
+    "id": "eac4e7b7-6520-487a-904a-f6f66f12caa1",
+    "type": "bugfix",
+    "description": "Make X-Amz-Checksum-Mode appear on query parameters on presigned URLs",
+    "modules": [
+        "."
+    ]
+}

--- a/aws/signer/internal/v4/headers.go
+++ b/aws/signer/internal/v4/headers.go
@@ -58,7 +58,10 @@ var RequiredSignedHeaders = Rules{
 			"X-Amz-Tagging":                                               struct{}{},
 		},
 	},
-	Patterns{"X-Amz-Checksum-"},
+	InclusiveRules{
+		Patterns{"X-Amz-Checksum-"},
+		ExcludeList{Patterns{"X-Amz-Checksum-Mode"}},
+	},
 	Patterns{"X-Amz-Object-Lock-"},
 	Patterns{"X-Amz-Meta-"},
 }

--- a/aws/signer/internal/v4/headers_test.go
+++ b/aws/signer/internal/v4/headers_test.go
@@ -51,6 +51,14 @@ func TestAllowedQueryHoisting(t *testing.T) {
 			Header:      "X-Amz-Checksum-Somefuturealgorithm",
 			ExpectHoist: false,
 		},
+		// x-amz-checksum-mode is a read-side request flag on GetObject/HeadObject,
+		// not a checksum value header. It must be hoisted (not signed) so presigned
+		// GET URLs work with plain HTTP clients that never send the header.
+		// Regression test for https://github.com/aws/aws-sdk-go-v2/issues/3528.
+		"checksum mode": {
+			Header:      "X-Amz-Checksum-Mode",
+			ExpectHoist: true,
+		},
 	}
 
 	for name, c := range cases {


### PR DESCRIPTION
Fixes #3528

We merged #3522 to make `x-amz-checksum-*` headers always appear as headers and not as query parameters. The idea was to catch all different algorithms that S3 has, like `X-Amz-Checksum-Xxhash64` or `X-Amz-Checksum-Sha256`, as well as `X-Amz-Checksum-Algorithm`. However, this also caught `X-Amz-Checksum-Mode`.

This is problematic since by default, the SDK injects `x-amz-checksum-mode: ENABLED` on every request. After the change, this is added on "signed headers" and customers are expected to provide it. If someone just has this as a plain URL and doesn't send headers, this will fail.