### PR TITLE
fix internal timeouts to not depend on the env

### DIFF
--- a/.changelog/abdae269760b4530abbb6df71465c6f2.json
+++ b/.changelog/abdae269760b4530abbb6df71465c6f2.json
@@ -1,0 +1,8 @@
+{
+    "id": "abdae269-760b-4530-abbb-6df71465c6f2",
+    "type": "bugfix",
+    "description": "Fix internal timeout gate to not depend on env opt-in.",
+    "modules": [
+        "."
+    ]
+}

--- a/internal/timeouts/awsinternal.go
+++ b/internal/timeouts/awsinternal.go
@@ -1,6 +1,6 @@
 package timeouts
 
 // Enabled internally.
-const enableReadTimeout2026 = false
+var enableReadTimeout2026 = false
 
 var readTimeout2026Rollout map[string]bool

--- a/internal/timeouts/timeouts.go
+++ b/internal/timeouts/timeouts.go
@@ -19,8 +19,10 @@ var enableFromEnv = sync.OnceValue(func() bool {
 // GetServiceReadTimeout reports the SDK's default read timeout for a service,
 // and whether one applies.
 func GetServiceReadTimeout(serviceID string) (time.Duration, bool) {
-	if enableReadTimeout2026 && !readTimeout2026Rollout[serviceID] {
-		return 0, false
+	if enableReadTimeout2026 {
+		if !readTimeout2026Rollout[serviceID] {
+			return 0, false
+		}
 	} else if !enableFromEnv() {
 		return 0, false
 	}

--- a/internal/timeouts/timeouts_test.go
+++ b/internal/timeouts/timeouts_test.go
@@ -14,6 +14,19 @@ func setGate(t *testing.T, on bool) {
 	t.Cleanup(func() { enableFromEnv = prev })
 }
 
+func setInternalGate(t *testing.T, on bool, rollout map[string]bool) {
+	t.Helper()
+
+	prevEnabled := enableReadTimeout2026
+	prevRollout := readTimeout2026Rollout
+	enableReadTimeout2026 = on
+	readTimeout2026Rollout = rollout
+	t.Cleanup(func() {
+		enableReadTimeout2026 = prevEnabled
+		readTimeout2026Rollout = prevRollout
+	})
+}
+
 func TestGetServiceReadTimeout(t *testing.T) {
 	for name, tt := range map[string]struct {
 		serviceID string
@@ -54,5 +67,75 @@ func TestGetServiceReadTimeout(t *testing.T) {
 				t.Errorf("expect %v, got %v", tt.expect, got)
 			}
 		})
+	}
+}
+
+func TestGetServiceReadTimeout_InternalGate(t *testing.T) {
+	for name, tt := range map[string]struct {
+		serviceID string
+		rollout   map[string]bool
+		envGate   bool
+		expect    time.Duration
+		expectOK  bool
+	}{
+		"service in rollout applies default, envGate irrelevant": {
+			serviceID: "DynamoDB",
+			rollout:   map[string]bool{"DynamoDB": true},
+			envGate:   false,
+			expect:    5 * time.Minute, expectOK: true,
+		},
+		"service in rollout applies default even with envGate on": {
+			serviceID: "DynamoDB",
+			rollout:   map[string]bool{"DynamoDB": true},
+			envGate:   true,
+			expect:    5 * time.Minute, expectOK: true,
+		},
+		"service not in rollout gets nothing": {
+			serviceID: "DynamoDB",
+			rollout:   map[string]bool{"SQS": true},
+			envGate:   false,
+		},
+		"nil rollout map gets nothing": {
+			serviceID: "DynamoDB",
+			rollout:   nil,
+			envGate:   false,
+		},
+		"exempt service in rollout still gets nothing": {
+			serviceID: "S3",
+			rollout:   map[string]bool{"S3": true},
+			envGate:   false,
+		},
+		"long-hold service in rollout gets the relaxed value": {
+			serviceID: "SQS",
+			rollout:   map[string]bool{"SQS": true},
+			envGate:   false,
+			expect:    15 * time.Minute, expectOK: true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			setGate(t, tt.envGate)
+			setInternalGate(t, true, tt.rollout)
+
+			got, ok := GetServiceReadTimeout(tt.serviceID)
+			if ok != tt.expectOK {
+				t.Fatalf("expect ok %v, got %v", tt.expectOK, ok)
+			}
+			if ok && got != tt.expect {
+				t.Errorf("expect %v, got %v", tt.expect, got)
+			}
+		})
+	}
+}
+
+func TestGetServiceReadTimeout_InternalGateOff(t *testing.T) {
+	setGate(t, true)
+	setInternalGate(t, false, map[string]bool{"DynamoDB": true})
+
+	got, ok := GetServiceReadTimeout("DynamoDB")
+	if !ok {
+		t.Fatalf("expect ok true, got false")
+	}
+	if got != 5*time.Minute {
+		t.Errorf("expect %v, got %v", 5*time.Minute, got)
 	}
 }


### PR DESCRIPTION
the if check here was bad since it also meant that the opt-in env had to be on, fixed this (it now totally ignores the env) and added explicit tests for it