### PR TITLE
fix downloadobject corruption caused by unequal part size

### DIFF
--- a/.changelog/a3cd07bca73a4818a997373b0d8812c7.json
+++ b/.changelog/a3cd07bca73a4818a997373b0d8812c7.json
@@ -1,0 +1,8 @@
+{
+    "id": "a3cd07bc-a73a-4818-a997-373b0d8812c7",
+    "type": "bugfix",
+    "description": "Fix DownloadObject bug so parts can be read to correct offset regardless of parts sizes change",
+    "modules": [
+        "feature/s3/transfermanager"
+    ]
+}

--- a/feature/s3/transfermanager/api_op_DownloadObject.go
+++ b/feature/s3/transfermanager/api_op_DownloadObject.go
@@ -571,7 +571,7 @@ func (d *downloader) download(ctx context.Context) (*DownloadObjectOutput, error
 	clientOptions := []func(*s3.Options){
 		func(o *s3.Options) {
 			o.APIOptions = append(o.APIOptions,
-				middleware.AddSDKAgentKey(middleware.FeatureMetadata, userAgentKey),
+				middleware.AddSDKAgentKeyValue(middleware.FeatureMetadata, userAgentKey, goModuleVersion),
 				addFeatureUserAgent,
 			)
 		}}
@@ -797,6 +797,19 @@ func (d *downloader) tryDownloadChunk(ctx context.Context, params *s3.GetObjectI
 		if reqStart != 0 && (reqStart != respStart || reqEnd != respEnd) {
 			return nil, fmt.Errorf("range mismatch between request %d-%d and response %d-%d", reqStart, reqEnd, respStart, respEnd)
 		}
+	}
+
+	if params.PartNumber != nil && out.ContentRange != nil {
+		// The parts of a multipart object may have unequal sizes, so the
+		// queue-time chunk start — computed by advancing part 1's size once
+		// per part — can point at the wrong offset. The part's absolute
+		// offset in the assembled object is authoritative in the response
+		// Content-Range; correct the write offset from it.
+		respStart, _, err := getRespRange(aws.ToString(out.ContentRange))
+		if err != nil {
+			return nil, err
+		}
+		chunk.start = respStart
 	}
 
 	d.totalBytesOnce.Do(func() {

--- a/feature/s3/transfermanager/api_op_DownloadObject_integ_test.go
+++ b/feature/s3/transfermanager/api_op_DownloadObject_integ_test.go
@@ -60,3 +60,41 @@ func TestInteg_DownloadObject(t *testing.T) {
 		})
 	}
 }
+
+// TestInteg_DownloadObject_UnequalSize verifies that downloading a multipart
+// object whose parts have unequal sizes returns exactly the uploaded content,
+// in both parts and ranges modes (#3526).
+func TestInteg_DownloadObject_UnequalSize(t *testing.T) {
+	const mib = 1024 * 1024
+	// Distinct byte patterns per part so any misplacement corrupts the result.
+	// All parts but the last are >= 5MB to satisfy the S3 minimum part size.
+	partA := bytes.Repeat([]byte{'A'}, 6*mib)
+	partB := bytes.Repeat([]byte{'B'}, 5*mib)
+	partC := bytes.Repeat([]byte{'C'}, 1*mib)
+	body := bytes.Join([][]byte{partA, partB, partC}, nil)
+	partSizes := []int64{6 * mib, 5 * mib, 1 * mib}
+
+	cases := map[string]downloadObjectTestData{
+		"parts get unequal part sizes": {
+			Body:       bytes.NewReader(body),
+			ExpectBody: body,
+			PartSizes:  partSizes,
+		},
+		"ranges get unequal part sizes": {
+			Body:       bytes.NewReader(body),
+			ExpectBody: body,
+			PartSizes:  partSizes,
+			OptFns: []func(*Options){
+				func(opt *Options) {
+					opt.GetObjectType = types.GetObjectRanges
+				},
+			},
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			testDownloadObjectWithChangingPartSize(t, setupMetadata.Buckets.Source.Name, c)
+		})
+	}
+}

--- a/feature/s3/transfermanager/api_op_UploadObject.go
+++ b/feature/s3/transfermanager/api_op_UploadObject.go
@@ -843,7 +843,7 @@ func (u *uploader) upload(ctx context.Context) (*UploadObjectOutput, error) {
 		func(o *s3.Options) {
 			o.RequestChecksumCalculation = u.options.RequestChecksumCalculation
 			o.APIOptions = append(o.APIOptions,
-				middleware.AddSDKAgentKey(middleware.FeatureMetadata, userAgentKey),
+				middleware.AddSDKAgentKeyValue(middleware.FeatureMetadata, userAgentKey, goModuleVersion),
 				addFeatureUserAgent,
 				func(s *smithymiddleware.Stack) error {
 					return s.Finalize.Insert(&setS3ExpressDefaultChecksum{}, "ResolveEndpointV2", smithymiddleware.After)

--- a/feature/s3/transfermanager/downloadobject_test.go
+++ b/feature/s3/transfermanager/downloadobject_test.go
@@ -23,6 +23,7 @@ const megabyte = 1024 * 1024
 func TestDownloadObject(t *testing.T) {
 	cases := map[string]struct {
 		data                 []byte
+		partsData            [][]byte
 		errReaders           []s3testing.TestErrReader
 		getObjectFn          func(*s3testing.TransferManagerLoggingClient, *s3.GetObjectInput) (*s3.GetObjectOutput, error)
 		rng                  string
@@ -302,6 +303,58 @@ func TestDownloadObject(t *testing.T) {
 				l.expectByteTransfers(t, 2*megabyte, 4*megabyte, 6*megabyte)
 			},
 		},
+		"parts download with unequal part sizes": {
+			// A multipart upload can produce parts of unequal sizes; the
+			// queue-time offsets assumed part 1's size for every part and
+			// corrupted the assembled object (#3526).
+			partsData: [][]byte{
+				bytes.Repeat([]byte{'A'}, 2*megabyte),
+				bytes.Repeat([]byte{'B'}, megabyte),
+				bytes.Repeat([]byte{'C'}, 3*megabyte),
+			},
+			getObjectFn: s3testing.UnequalPartGetObjectFn,
+			optFn: func(o *Options) {
+				o.Concurrency = 1
+			},
+			partsCount:        3,
+			expectInvocations: 3,
+			expectParts:       []int32{1, 2, 3},
+			dataValidationFn: func(t *testing.T, w *types.WriteAtBuffer) {
+				expect := bytes.Join([][]byte{
+					bytes.Repeat([]byte{'A'}, 2*megabyte),
+					bytes.Repeat([]byte{'B'}, megabyte),
+					bytes.Repeat([]byte{'C'}, 3*megabyte),
+				}, nil)
+				if e, a := len(expect), len(w.Bytes()); e != a {
+					t.Fatalf("expect %d bytes, got %d", e, a)
+				}
+				if e, a := expect, w.Bytes(); !bytes.Equal(e, a) {
+					t.Fatalf("expect downloaded object to equal the assembled parts")
+				}
+			},
+		},
+		"parts download with unequal part sizes and concurrency": {
+			partsData: [][]byte{
+				bytes.Repeat([]byte{'A'}, 2*megabyte),
+				bytes.Repeat([]byte{'B'}, megabyte),
+				bytes.Repeat([]byte{'C'}, 3*megabyte),
+			},
+			getObjectFn: s3testing.UnequalPartGetObjectFn,
+			// default concurrency (5) exercises the multi-goroutine path
+			optFn:             func(o *Options) {},
+			partsCount:        3,
+			expectInvocations: 3,
+			dataValidationFn: func(t *testing.T, w *types.WriteAtBuffer) {
+				expect := bytes.Join([][]byte{
+					bytes.Repeat([]byte{'A'}, 2*megabyte),
+					bytes.Repeat([]byte{'B'}, megabyte),
+					bytes.Repeat([]byte{'C'}, 3*megabyte),
+				}, nil)
+				if e, a := expect, w.Bytes(); !bytes.Equal(e, a) {
+					t.Fatalf("expect downloaded object to equal the assembled parts")
+				}
+			},
+		},
 		"parts download in order with composite checksum type": {
 			data:        buf2MB,
 			getObjectFn: s3testing.CompositePartGetObjectFn,
@@ -445,6 +498,7 @@ func TestDownloadObject(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			s3Client, invocations, parts, ranges, versions, etags := s3testing.NewDownloadClient()
 			s3Client.Data = c.data
+			s3Client.PartsData = c.partsData
 			s3Client.GetObjectFn = c.getObjectFn
 			s3Client.ErrReaders = c.errReaders
 			s3Client.PartsCount = c.partsCount

--- a/feature/s3/transfermanager/internal/testing/client.go
+++ b/feature/s3/transfermanager/internal/testing/client.go
@@ -406,6 +406,30 @@ var ReaderPartGetObjectFn = func(c *TransferManagerLoggingClient, params *s3.Get
 	}, nil
 }
 
+// UnequalPartGetObjectFn mocks getobject behavior of s3 client to return
+// object parts of unequal sizes, as a multipart upload may produce. Unlike
+// ReaderPartGetObjectFn it also returns the Content-Range of each part,
+// which is what S3 includes in part-number GetObject responses.
+var UnequalPartGetObjectFn = func(c *TransferManagerLoggingClient, params *s3.GetObjectInput) (*s3.GetObjectOutput, error) {
+	index := aws.ToInt32(params.PartNumber) - 1
+	total := 0
+	for _, p := range c.PartsData {
+		total += len(p)
+	}
+	start := 0
+	for _, p := range c.PartsData[:index] {
+		start += len(p)
+	}
+	part := c.PartsData[index]
+	return &s3.GetObjectOutput{
+		Body:          io.NopCloser(bytes.NewReader(part)),
+		ContentLength: aws.Int64(int64(len(part))),
+		ContentRange:  aws.String(fmt.Sprintf("bytes %d-%d/%d", start, start+len(part)-1, total)),
+		PartsCount:    aws.Int32(c.PartsCount),
+		ETag:          aws.String(etag),
+	}, nil
+}
+
 // CompositePartGetObjectFn mocks getobject behavior of s3 client to return object with composite checksum type and checksum value
 var CompositePartGetObjectFn = func(c *TransferManagerLoggingClient, params *s3.GetObjectInput) (*s3.GetObjectOutput, error) {
 	return &s3.GetObjectOutput{

--- a/feature/s3/transfermanager/setup_integ_test.go
+++ b/feature/s3/transfermanager/setup_integ_test.go
@@ -227,6 +227,11 @@ type downloadObjectTestData struct {
 	ExpectBody  []byte
 	ExpectError string
 	OptFns      []func(*Options)
+	// PartSizes, when set, uploads Body as a multipart object whose parts
+	// have exactly these byte sizes (all but the last must be >= 5MB per the
+	// S3 minimum). Used to exercise downloads of objects with unequal part
+	// sizes (#3526).
+	PartSizes []int64
 }
 
 type getObjectTestData struct {
@@ -391,6 +396,108 @@ func testDownloadObject(t *testing.T, bucket string, testData downloadObjectTest
 
 	if e, a := testData.ExpectBody, w.Bytes(); !bytes.EqualFold(e, a) {
 		t.Errorf("expect %s, got %s", e, a)
+	}
+}
+
+// testDownloadObjectWithChangingPartSize uploads testData.Body as a multipart
+// object whose parts have unequal sizes (testData.PartSizes), then downloads it
+// through the transfer manager and asserts the downloaded bytes exactly equal
+// what was uploaded. This exercises the download path that must not assume all
+// parts share the first part's size (#3526). S3 requires every part except the
+// last to be at least 5MB, so PartSizes must respect that.
+func testDownloadObjectWithChangingPartSize(t *testing.T, bucket string, testData downloadObjectTestData) {
+	key := UniqueID()
+
+	body, err := io.ReadAll(testData.Body)
+	if err != nil {
+		t.Fatalf("expect no error reading test body, got %v", err)
+	}
+
+	var total int64
+	for _, s := range testData.PartSizes {
+		total += s
+	}
+	if total != int64(len(body)) {
+		t.Fatalf("PartSizes sum to %d but body is %d bytes; they must match", total, len(body))
+	}
+
+	createOut, err := s3Client.CreateMultipartUpload(context.Background(),
+		&s3.CreateMultipartUploadInput{
+			Bucket: aws.String(bucket),
+			Key:    aws.String(key),
+		})
+	if err != nil {
+		t.Fatalf("expect no error creating multipart upload, got %v", err)
+	}
+	uploadID := createOut.UploadId
+
+	abort := func() {
+		_, _ = s3Client.AbortMultipartUpload(context.Background(),
+			&s3.AbortMultipartUploadInput{
+				Bucket:   aws.String(bucket),
+				Key:      aws.String(key),
+				UploadId: uploadID,
+			})
+	}
+
+	var completedParts []s3types.CompletedPart
+	var offset int64
+	for i, size := range testData.PartSizes {
+		partNum := int32(i + 1)
+		partOut, err := s3Client.UploadPart(context.Background(),
+			&s3.UploadPartInput{
+				Bucket:     aws.String(bucket),
+				Key:        aws.String(key),
+				UploadId:   uploadID,
+				PartNumber: aws.Int32(partNum),
+				Body:       bytes.NewReader(body[offset : offset+size]),
+			})
+		if err != nil {
+			abort()
+			t.Fatalf("expect no error uploading part %d, got %v", partNum, err)
+		}
+		completedParts = append(completedParts, s3types.CompletedPart{
+			ETag:       partOut.ETag,
+			PartNumber: aws.Int32(partNum),
+		})
+		offset += size
+	}
+
+	if _, err = s3Client.CompleteMultipartUpload(context.Background(),
+		&s3.CompleteMultipartUploadInput{
+			Bucket:          aws.String(bucket),
+			Key:             aws.String(key),
+			UploadId:        uploadID,
+			MultipartUpload: &s3types.CompletedMultipartUpload{Parts: completedParts},
+		}); err != nil {
+		abort()
+		t.Fatalf("expect no error completing multipart upload, got %v", err)
+	}
+
+	w := types.NewWriteAtBuffer(make([]byte, 0))
+	_, err = s3TransferManagerClient.DownloadObject(context.Background(),
+		&DownloadObjectInput{
+			Bucket:   aws.String(bucket),
+			Key:      aws.String(key),
+			WriterAt: w,
+			Range:    aws.String(testData.Range),
+		}, testData.OptFns...)
+	if err != nil {
+		if len(testData.ExpectError) == 0 {
+			t.Fatalf("expect no error, got %v", err)
+		}
+		if e, a := testData.ExpectError, err.Error(); !strings.Contains(a, e) {
+			t.Fatalf("expect error to contain %v, got %v", e, a)
+		}
+	} else if e := testData.ExpectError; len(e) != 0 {
+		t.Fatalf("expect error: %v, got none", e)
+	}
+	if len(testData.ExpectError) != 0 {
+		return
+	}
+
+	if e, a := testData.ExpectBody, w.Bytes(); !bytes.Equal(e, a) {
+		t.Errorf("expect downloaded object to equal uploaded object: uploaded %d bytes, got %d bytes", len(e), len(a))
 	}
 }
 


### PR DESCRIPTION
1. Fixes #3526 by referring to #3527 , 
2. Add version number for tm v2 apis to get metrics of user importing safety versions 

the GetObject fix will come later