### PR TITLE
Fix getter partsizecorruption

### DIFF
--- a/.changelog/cf7a0fdf856044dba96a446642d3e151.json
+++ b/.changelog/cf7a0fdf856044dba96a446642d3e151.json
@@ -1,0 +1,8 @@
+{
+    "id": "cf7a0fdf-8560-44db-a96a-446642d3e151",
+    "type": "bugfix",
+    "description": "Fix GetObject bug so object parts can be read to correct offset regardless of parts sizes change",
+    "modules": [
+        "feature/s3/transfermanager"
+    ]
+}

--- a/feature/s3/transfermanager/api_op_GetObject.go
+++ b/feature/s3/transfermanager/api_op_GetObject.go
@@ -618,12 +618,13 @@ func (g *getter) get(ctx context.Context) (out *GetObjectOutput, err error) {
 		}}
 
 	r := &concurrentReader{
-		ctx:      ctx,
-		buf:      make(map[int32]*outChunk),
-		partSize: 1,
-		options:  g.options.Copy(),
-		in:       g.in,
-		ch:       make(chan outChunk, g.options.Concurrency),
+		ctx:             ctx,
+		buf:             make(map[int32]*outChunk),
+		partSize:        1,
+		options:         g.options.Copy(),
+		in:              g.in,
+		ch:              make(chan outChunk, g.options.Concurrency),
+		bufferThreshold: g.options.GetObjectBufferSize,
 	}
 
 	output := &GetObjectOutput{}

--- a/feature/s3/transfermanager/api_op_GetObject.go
+++ b/feature/s3/transfermanager/api_op_GetObject.go
@@ -612,7 +612,7 @@ func (g *getter) get(ctx context.Context) (out *GetObjectOutput, err error) {
 	clientOptions := []func(*s3.Options){
 		func(o *s3.Options) {
 			o.APIOptions = append(o.APIOptions,
-				middleware.AddSDKAgentKey(middleware.FeatureMetadata, userAgentKey),
+				middleware.AddSDKAgentKeyValue(middleware.FeatureMetadata, userAgentKey, goModuleVersion),
 				addFeatureUserAgent,
 			)
 		}}
@@ -658,6 +658,7 @@ func (g *getter) get(ctx context.Context) (out *GetObjectOutput, err error) {
 		r.partSize = partSize
 		atomic.StoreInt32(&r.capacity, min(capacity, partsCount))
 		r.partsCount = partsCount
+		r.getType = types.GetObjectParts
 	} else {
 		out, err := g.options.S3.HeadObject(ctx, &s3.HeadObjectInput{
 			Bucket:               g.in.Bucket,
@@ -701,6 +702,7 @@ func (g *getter) get(ctx context.Context) (out *GetObjectOutput, err error) {
 		r.partsCount = partsCount
 		r.sectionParts = sectionParts
 		r.totalBytes = total
+		r.getType = types.GetObjectRanges
 	}
 
 	r.etag = output.ETag

--- a/feature/s3/transfermanager/api_op_GetObject_integ_test.go
+++ b/feature/s3/transfermanager/api_op_GetObject_integ_test.go
@@ -60,3 +60,41 @@ func TestInteg_GetObject(t *testing.T) {
 		})
 	}
 }
+
+// TestInteg_GetObject_UnequalSize verifies that streaming a multipart object
+// whose parts have unequal sizes returns exactly the uploaded content, in both
+// parts and ranges modes (#3526).
+func TestInteg_GetObject_UnequalSize(t *testing.T) {
+	const mib = 1024 * 1024
+	// Distinct byte patterns per part so any misplacement corrupts the result.
+	// All parts but the last are >= 5MB to satisfy the S3 minimum part size.
+	partA := bytes.Repeat([]byte{'A'}, 6*mib)
+	partB := bytes.Repeat([]byte{'B'}, 5*mib)
+	partC := bytes.Repeat([]byte{'C'}, 1*mib)
+	body := bytes.Join([][]byte{partA, partB, partC}, nil)
+	partSizes := []int64{6 * mib, 5 * mib, 1 * mib}
+
+	cases := map[string]getObjectTestData{
+		"parts get unequal part sizes": {
+			Body:       bytes.NewReader(body),
+			ExpectBody: body,
+			PartSizes:  partSizes,
+		},
+		"ranges get unequal part sizes": {
+			Body:       bytes.NewReader(body),
+			ExpectBody: body,
+			PartSizes:  partSizes,
+			OptFns: []func(*Options){
+				func(opt *Options) {
+					opt.GetObjectType = types.GetObjectRanges
+				},
+			},
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			testGetObjectWithChangingPartSize(t, setupMetadata.Buckets.Source.Name, c)
+		})
+	}
+}

--- a/feature/s3/transfermanager/concurrent_reader.go
+++ b/feature/s3/transfermanager/concurrent_reader.go
@@ -23,21 +23,24 @@ type concurrentReader struct {
 	buf     map[int32]*outChunk
 	options Options
 	in      *GetObjectInput
+	getType types.GetObjectType
 
-	pos          int64
-	partsCount   int32
-	capacity     int32
-	sectionParts int32
-	sendCount    int32
-	receiveCount int32
-	readCount    int32
-	totalBytes   int64
-	index        int32
-	done         bool
-	written      int64
-	partSize     int64
-	invocations  int32
-	etag         *string
+	pos              int64
+	partsCount       int32
+	capacity         int32
+	sectionParts     int32
+	sendCount        int32
+	receiveCount     int32
+	readCount        int32
+	consecutiveIndex int32 // the sequential idx marking the next consecutive part being read
+	buffered         int64
+	totalBytes       int64
+	index            int32
+	done             bool
+	written          int64
+	partSize         int64
+	invocations      int32
+	etag             *string
 
 	ctx context.Context
 	m   sync.Mutex
@@ -58,7 +61,7 @@ func (r *concurrentReader) Read(p []byte) (int, error) {
 	clientOptions := []func(*s3.Options){
 		func(o *s3.Options) {
 			o.APIOptions = append(o.APIOptions,
-				middleware.AddSDKAgentKey(middleware.FeatureMetadata, userAgentKey),
+				middleware.AddSDKAgentKeyValue(middleware.FeatureMetadata, userAgentKey, goModuleVersion),
 				addFeatureUserAgent,
 			)
 		}}
@@ -204,6 +207,102 @@ func (r *concurrentReader) read(p []byte) (int, error) {
 		return 0, nil
 	}
 
+	if r.getType == types.GetObjectParts {
+		return r.partRead(p)
+	}
+
+	return r.rangeRead(p)
+}
+
+func (r *concurrentReader) partRead(p []byte) (int, error) {
+	var written int
+
+	for i := r.consecutiveIndex; i < atomic.LoadInt32(&r.capacity); i++ {
+		if e := r.getErr(); e != nil && e != io.EOF {
+			r.clean()
+			return written, r.getErr()
+		}
+
+		c, ok := r.buf[i]
+		if !ok {
+			// possible unequal parts' sizes can break all offset read for part GET,
+			// must break and wait for next consecutive part
+			break
+		}
+		if written >= cap(p) {
+			return written, nil
+		}
+
+		n, err := c.body.Read(p[written:])
+		c.cur += int64(n)
+		written += n
+		if err != nil && err != io.EOF {
+			r.setErr(err)
+			r.clean()
+			return written, r.getErr()
+		}
+		if c.cur >= c.length {
+			r.readCount++
+			delete(r.buf, i)
+			r.buffered -= c.length
+
+			if r.readCount == atomic.LoadInt32(&r.capacity) {
+				capacity := min(atomic.LoadInt32(&r.capacity)+r.sectionParts, r.partsCount)
+				atomic.StoreInt32(&r.capacity, capacity)
+			}
+			if r.readCount >= r.partsCount {
+				r.setErr(io.EOF)
+			}
+		}
+	}
+
+	for r.receiveCount < atomic.LoadInt32(&r.capacity) {
+		if e := r.getErr(); e != nil && e != io.EOF {
+			r.clean()
+			return written, e
+		}
+
+		oc, ok := <-r.ch
+		if !ok {
+			break
+		}
+		r.receiveCount++
+		if written >= cap(p) {
+			return written, nil
+		}
+		// only directly feed into p if this is the next neighbor part
+		if oc.index == r.consecutiveIndex {
+
+			n, err := oc.body.Read(p[written:])
+			oc.cur += int64(n)
+			written += n
+			if err != nil && err != io.EOF {
+				r.setErr(err)
+				r.clean()
+				return written, r.getErr()
+			}
+		} else {
+
+		}
+
+		if oc.cur < oc.length {
+			r.buf[oc.index] = &oc
+		} else {
+			r.readCount++
+			if r.readCount == atomic.LoadInt32(&r.capacity) {
+				capacity := min(atomic.LoadInt32(&r.capacity)+r.sectionParts, r.partsCount)
+				atomic.StoreInt32(&r.capacity, capacity)
+			}
+			if r.readCount >= r.partsCount {
+				r.setErr(io.EOF)
+			}
+		}
+	}
+
+	return written, r.getErr()
+}
+
+func (r *concurrentReader) rangeRead(p []byte) (int, error) {
 	var written int
 
 	partSize := r.partSize

--- a/feature/s3/transfermanager/concurrent_reader.go
+++ b/feature/s3/transfermanager/concurrent_reader.go
@@ -25,6 +25,7 @@ type concurrentReader struct {
 	in      *GetObjectInput
 	getType types.GetObjectType
 
+	bufferThreshold  int64
 	pos              int64
 	partsCount       int32
 	capacity         int32
@@ -223,14 +224,15 @@ func (r *concurrentReader) partRead(p []byte) (int, error) {
 			return written, r.getErr()
 		}
 
+		if written >= cap(p) {
+			return written, nil
+		}
+
 		c, ok := r.buf[i]
 		if !ok {
 			// possible unequal parts' sizes can break all offset read for part GET,
 			// must break and wait for next consecutive part
 			break
-		}
-		if written >= cap(p) {
-			return written, nil
 		}
 
 		n, err := c.body.Read(p[written:])
@@ -242,17 +244,15 @@ func (r *concurrentReader) partRead(p []byte) (int, error) {
 			return written, r.getErr()
 		}
 		if c.cur >= c.length {
+			r.consecutiveIndex++
 			r.readCount++
 			delete(r.buf, i)
 			r.buffered -= c.length
 
-			if r.readCount == atomic.LoadInt32(&r.capacity) {
-				capacity := min(atomic.LoadInt32(&r.capacity)+r.sectionParts, r.partsCount)
-				atomic.StoreInt32(&r.capacity, capacity)
-			}
 			if r.readCount >= r.partsCount {
 				r.setErr(io.EOF)
 			}
+			r.maybeGrowCapacity()
 		}
 	}
 
@@ -267,12 +267,9 @@ func (r *concurrentReader) partRead(p []byte) (int, error) {
 			break
 		}
 		r.receiveCount++
-		if written >= cap(p) {
-			return written, nil
-		}
-		// only directly feed into p if this is the next neighbor part
-		if oc.index == r.consecutiveIndex {
 
+		// only directly feed into p if this is the next neighbor part
+		if oc.index == r.consecutiveIndex && written < cap(p) {
 			n, err := oc.body.Read(p[written:])
 			oc.cur += int64(n)
 			written += n
@@ -281,18 +278,19 @@ func (r *concurrentReader) partRead(p []byte) (int, error) {
 				r.clean()
 				return written, r.getErr()
 			}
-		} else {
-
 		}
 
 		if oc.cur < oc.length {
 			r.buf[oc.index] = &oc
+			r.buffered += oc.length
 		} else {
 			r.readCount++
-			if r.readCount == atomic.LoadInt32(&r.capacity) {
-				capacity := min(atomic.LoadInt32(&r.capacity)+r.sectionParts, r.partsCount)
-				atomic.StoreInt32(&r.capacity, capacity)
-			}
+			r.consecutiveIndex++
+			// Bound memory by throttling how many parts we dispatch (via capacity),
+			// never by abandoning parts already in flight. partRead must drain every
+			// dispatched part; otherwise a download producer blocks forever on a full
+			// r.ch and hangs Read's r.wg.Wait().
+			r.maybeGrowCapacity()
 			if r.readCount >= r.partsCount {
 				r.setErr(io.EOF)
 			}
@@ -300,6 +298,26 @@ func (r *concurrentReader) partRead(p []byte) (int, error) {
 	}
 
 	return written, r.getErr()
+}
+
+// maybeGrowCapacity advances the dispatch ceiling (capacity) to request more
+// parts while the estimated in-memory footprint stays under bufferThreshold. It
+// always keeps the next part to be read dispatched so the stream makes progress
+// even when a single part is larger than the whole budget. capacity only grows
+// and never exceeds partsCount, so partRead always drains every dispatched part
+// (receiveCount reaches capacity), which keeps download producers from blocking
+// on a full r.ch.
+func (r *concurrentReader) maybeGrowCapacity() {
+	c := atomic.LoadInt32(&r.capacity)
+	if c >= r.partsCount {
+		return
+	}
+	// committed = buffered (received, not yet consumed) + an estimate for parts
+	// dispatched but not yet received, using the first part's size per part.
+	committed := r.buffered + int64(c-r.receiveCount)*r.partSize
+	if c <= r.consecutiveIndex || committed < r.bufferThreshold {
+		atomic.StoreInt32(&r.capacity, c+1)
+	}
 }
 
 func (r *concurrentReader) rangeRead(p []byte) (int, error) {

--- a/feature/s3/transfermanager/concurrent_reader_test.go
+++ b/feature/s3/transfermanager/concurrent_reader_test.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	s3testing "github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager/internal/testing"
@@ -263,5 +264,163 @@ func TestConcurrentReaderReadRepeatAfterError(t *testing.T) {
 
 	if got := s3Client.GetObjectInvocations; got != firstReadInvocations {
 		t.Fatalf("expected repeated read not to schedule more downloads, got %d GetObject calls after %d on first read", got, firstReadInvocations)
+	}
+}
+
+// TestConcurrentReaderPartUnequalSizes exercises the parts-mode read path
+// (partRead) with multipart objects whose parts have unequal sizes (#3526).
+// The existing TestConcurrentReader cases don't set getType/bufferThreshold, so
+// they route through rangeRead; these cases set both to drive partRead directly,
+// covering large and small memory thresholds and single/multi goroutine paths.
+func TestConcurrentReaderPartUnequalSizes(t *testing.T) {
+	cases := map[string]struct {
+		sizes           []int
+		concurrency     int
+		bufferThreshold int64
+	}{
+		"conc1 large threshold":  {sizes: []int{60, 50, 10}, concurrency: 1, bufferThreshold: 1 << 20},
+		"conc5 large threshold":  {sizes: []int{60, 50, 10}, concurrency: 5, bufferThreshold: 1 << 20},
+		"conc5 small threshold":  {sizes: []int{60, 50, 49, 2}, concurrency: 5, bufferThreshold: 50},
+		"conc5 first part small": {sizes: []int{8, 50, 49, 2}, concurrency: 5, bufferThreshold: 50},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			partsData := make([][]byte, len(c.sizes))
+			var expect []byte
+			for i, s := range c.sizes {
+				b := bytes.Repeat([]byte{byte('A' + i)}, s)
+				partsData[i] = b
+				expect = append(expect, b...)
+			}
+
+			s3Client := &s3testing.TransferManagerLoggingClient{}
+			s3Client.GetObjectFn = s3testing.UnequalPartGetObjectFn
+			s3Client.PartsData = partsData
+			s3Client.PartsCount = int32(len(c.sizes))
+			s3Client.Data = expect
+
+			partSize := int64(c.sizes[0])
+			sectionParts := int32(c.bufferThreshold / partSize)
+			if sectionParts < 1 {
+				sectionParts = 1
+			}
+			partsCount := int32(len(c.sizes))
+			capacity := sectionParts
+			if capacity > partsCount {
+				capacity = partsCount
+			}
+
+			r := &concurrentReader{
+				partSize:        partSize,
+				partsCount:      partsCount,
+				sectionParts:    sectionParts,
+				getType:         types.GetObjectParts,
+				bufferThreshold: c.bufferThreshold,
+				options: Options{
+					GetObjectType: types.GetObjectParts,
+					Concurrency:   c.concurrency,
+					S3:            s3Client,
+				},
+				in:         &GetObjectInput{Bucket: aws.String("bucket"), Key: aws.String("key")},
+				capacity:   capacity,
+				buf:        make(map[int32]*outChunk),
+				ctx:        context.Background(),
+				ch:         make(chan outChunk, c.concurrency),
+				totalBytes: int64(len(expect)),
+			}
+
+			got, err := io.ReadAll(r)
+			if err != nil {
+				t.Fatalf("read error: %v", err)
+			}
+			if e, a := len(expect), len(got); e != a {
+				t.Fatalf("expect %d bytes, got %d", e, a)
+			}
+			if !bytes.Equal(expect, got) {
+				t.Fatalf("expect downloaded stream to equal assembled parts")
+			}
+		})
+	}
+}
+
+// TestConcurrentReaderPartMemoryThrottleNoDeadlock guards against the parts-mode
+// deadlock where bounding memory by breaking out of the receive loop orphaned an
+// in-flight download producer on a full r.ch and hung Read's r.wg.Wait() (#3526
+// follow-up). It reproduces the trigger conditions: sectionParts > Concurrency
+// (more parts dispatched than r.ch can buffer), unequal parts where later parts
+// are much larger than part 1, and a delayed part 0 so a large later part is
+// received first. Memory must be bounded by throttling dispatch, not by
+// abandoning received parts, so this must complete rather than hang.
+func TestConcurrentReaderPartMemoryThrottleNoDeadlock(t *testing.T) {
+	sizes := []int{10, 200, 200, 200, 200, 200}
+	partsData := make([][]byte, len(sizes))
+	var expect []byte
+	for i, s := range sizes {
+		b := bytes.Repeat([]byte{byte('A' + i)}, s)
+		partsData[i] = b
+		expect = append(expect, b...)
+	}
+
+	s3Client := &s3testing.TransferManagerLoggingClient{}
+	s3Client.PartsData = partsData
+	s3Client.PartsCount = int32(len(sizes))
+	s3Client.Data = expect
+	// Delay part 0 so a later, larger part is received first and would trip the
+	// memory budget before the consecutive part arrives.
+	s3Client.GetObjectFn = func(c *s3testing.TransferManagerLoggingClient, in *s3.GetObjectInput) (*s3.GetObjectOutput, error) {
+		if aws.ToInt32(in.PartNumber) == 1 {
+			time.Sleep(200 * time.Millisecond)
+		}
+		return s3testing.UnequalPartGetObjectFn(c, in)
+	}
+
+	partSize := int64(sizes[0]) // 10
+	bufferThreshold := int64(100)
+	sectionParts := int32(bufferThreshold / partSize) // 10, > Concurrency below
+	partsCount := int32(len(sizes))
+	capacity := sectionParts
+	if capacity > partsCount {
+		capacity = partsCount
+	}
+
+	r := &concurrentReader{
+		partSize:        partSize,
+		partsCount:      partsCount,
+		sectionParts:    sectionParts,
+		getType:         types.GetObjectParts,
+		bufferThreshold: bufferThreshold,
+		options: Options{
+			GetObjectType: types.GetObjectParts,
+			Concurrency:   2, // < sectionParts and < in-flight parts
+			S3:            s3Client,
+		},
+		in:         &GetObjectInput{Bucket: aws.String("bucket"), Key: aws.String("key")},
+		capacity:   capacity,
+		buf:        make(map[int32]*outChunk),
+		ctx:        context.Background(),
+		ch:         make(chan outChunk, 2),
+		totalBytes: int64(len(expect)),
+	}
+
+	done := make(chan struct{})
+	var got []byte
+	var err error
+	go func() {
+		got, err = io.ReadAll(r)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(15 * time.Second):
+		t.Fatal("Read did not complete: likely deadlocked on r.wg.Wait() with an orphaned download producer")
+	}
+
+	if err != nil {
+		t.Fatalf("read error: %v", err)
+	}
+	if !bytes.Equal(expect, got) {
+		t.Fatalf("expect %d bytes equal to assembled parts, got %d", len(expect), len(got))
 	}
 }

--- a/feature/s3/transfermanager/getobject_test.go
+++ b/feature/s3/transfermanager/getobject_test.go
@@ -614,3 +614,70 @@ func TestGetObject_HeadObjectForwardsRequiredFields(t *testing.T) {
 		})
 	}
 }
+
+// TestGetObjectUnequalParts exercises the full GetObject -> HeadObject ->
+// concurrentReader.partRead path for multipart objects whose parts have unequal
+// sizes (#3526). partRead must reassemble the stream in order regardless of part
+// layout, arrival order, or the memory budget. It also covers a tight
+// GetObjectBufferSize so the byte-throttled dispatch path is exercised end to end.
+func TestGetObjectUnequalParts(t *testing.T) {
+	const mib = 1024 * 1024
+	cases := map[string]struct {
+		sizes       []int
+		concurrency int
+		bufferSize  int64
+	}{
+		"single goroutine":       {sizes: []int{6 * mib, 5 * mib, 1 * mib}, concurrency: 1},
+		"multiple goroutines":    {sizes: []int{6 * mib, 5 * mib, 1 * mib}, concurrency: 5},
+		"largest middle part":    {sizes: []int{2 * mib, 9 * mib, 1 * mib, 4 * mib}, concurrency: 5},
+		"single part":            {sizes: []int{3 * mib}, concurrency: 5},
+		"tight buffer throttles": {sizes: []int{2 * mib, 9 * mib, 1 * mib, 4 * mib}, concurrency: 5, bufferSize: 3 * mib},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			partsData := make([][]byte, len(c.sizes))
+			var expect []byte
+			for i, s := range c.sizes {
+				// distinct byte per part so any misordering corrupts the result
+				b := bytes.Repeat([]byte{byte('A' + i)}, s)
+				partsData[i] = b
+				expect = append(expect, b...)
+			}
+
+			s3Client, _, _, _, _, _ := s3testing.NewDownloadClient()
+			s3Client.Data = expect
+			s3Client.PartsData = partsData
+			s3Client.PartsCount = int32(len(c.sizes))
+			s3Client.GetObjectFn = s3testing.UnequalPartGetObjectFn
+
+			mgr := New(s3Client, func(o *Options) {
+				o.GetObjectType = types.GetObjectParts
+				o.Concurrency = c.concurrency
+				if c.bufferSize != 0 {
+					o.GetObjectBufferSize = c.bufferSize
+				}
+			})
+
+			out, err := mgr.GetObject(context.Background(), &GetObjectInput{
+				Bucket: aws.String("bucket"),
+				Key:    aws.String("key"),
+			})
+			if err != nil {
+				t.Fatalf("expect no error getting object, got %v", err)
+			}
+
+			got, err := io.ReadAll(out.Body)
+			if err != nil {
+				t.Fatalf("expect no error reading body, got %v", err)
+			}
+
+			if e, a := len(expect), len(got); e != a {
+				t.Fatalf("expect %d bytes, got %d", e, a)
+			}
+			if !bytes.Equal(expect, got) {
+				t.Fatalf("expect downloaded object to equal the assembled parts")
+			}
+		})
+	}
+}

--- a/feature/s3/transfermanager/setup_integ_test.go
+++ b/feature/s3/transfermanager/setup_integ_test.go
@@ -241,6 +241,11 @@ type getObjectTestData struct {
 	ExpectGetError  string
 	ExpectReadError string
 	OptFns          []func(*Options)
+	// PartSizes, when set, uploads Body as a multipart object whose parts have
+	// exactly these byte sizes (all but the last must be >= 5MB per the S3
+	// minimum). Used to exercise GetObject of objects with unequal part sizes
+	// (#3526).
+	PartSizes []int64
 }
 
 // UniqueID returns a unique UUID-like identifier for use in generating
@@ -354,6 +359,117 @@ func testGetObject(t *testing.T, bucket string, testData getObjectTestData) {
 	}
 	if e, a := testData.ExpectBody, b; !bytes.EqualFold(e, a) {
 		t.Errorf("expect %s, got %s", e, a)
+	}
+}
+
+// testGetObjectWithChangingPartSize uploads testData.Body as a multipart object
+// whose parts have unequal sizes (testData.PartSizes), then reads it back through
+// the transfer manager's GetObject and asserts the streamed bytes exactly equal
+// what was uploaded. This exercises the parts-mode concurrent reader, which must
+// not assume all parts share the first part's size (#3526). S3 requires every
+// part except the last to be at least 5MB, so PartSizes must respect that.
+func testGetObjectWithChangingPartSize(t *testing.T, bucket string, testData getObjectTestData) {
+	key := UniqueID()
+
+	body, err := io.ReadAll(testData.Body)
+	if err != nil {
+		t.Fatalf("expect no error reading test body, got %v", err)
+	}
+
+	var total int64
+	for _, s := range testData.PartSizes {
+		total += s
+	}
+	if total != int64(len(body)) {
+		t.Fatalf("PartSizes sum to %d but body is %d bytes; they must match", total, len(body))
+	}
+
+	createOut, err := s3Client.CreateMultipartUpload(context.Background(),
+		&s3.CreateMultipartUploadInput{
+			Bucket: aws.String(bucket),
+			Key:    aws.String(key),
+		})
+	if err != nil {
+		t.Fatalf("expect no error creating multipart upload, got %v", err)
+	}
+	uploadID := createOut.UploadId
+
+	abort := func() {
+		_, _ = s3Client.AbortMultipartUpload(context.Background(),
+			&s3.AbortMultipartUploadInput{
+				Bucket:   aws.String(bucket),
+				Key:      aws.String(key),
+				UploadId: uploadID,
+			})
+	}
+
+	var completedParts []s3types.CompletedPart
+	var offset int64
+	for i, size := range testData.PartSizes {
+		partNum := int32(i + 1)
+		partOut, err := s3Client.UploadPart(context.Background(),
+			&s3.UploadPartInput{
+				Bucket:     aws.String(bucket),
+				Key:        aws.String(key),
+				UploadId:   uploadID,
+				PartNumber: aws.Int32(partNum),
+				Body:       bytes.NewReader(body[offset : offset+size]),
+			})
+		if err != nil {
+			abort()
+			t.Fatalf("expect no error uploading part %d, got %v", partNum, err)
+		}
+		completedParts = append(completedParts, s3types.CompletedPart{
+			ETag:       partOut.ETag,
+			PartNumber: aws.Int32(partNum),
+		})
+		offset += size
+	}
+
+	if _, err = s3Client.CompleteMultipartUpload(context.Background(),
+		&s3.CompleteMultipartUploadInput{
+			Bucket:          aws.String(bucket),
+			Key:             aws.String(key),
+			UploadId:        uploadID,
+			MultipartUpload: &s3types.CompletedMultipartUpload{Parts: completedParts},
+		}); err != nil {
+		abort()
+		t.Fatalf("expect no error completing multipart upload, got %v", err)
+	}
+
+	out, err := s3TransferManagerClient.GetObject(context.Background(),
+		&GetObjectInput{
+			Bucket: aws.String(bucket),
+			Key:    aws.String(key),
+			Range:  aws.String(testData.Range),
+		}, testData.OptFns...)
+	if err != nil {
+		if len(testData.ExpectGetError) == 0 {
+			t.Fatalf("expect no error when getting object, got %v", err)
+		}
+		if e, a := testData.ExpectGetError, err.Error(); !strings.Contains(a, e) {
+			t.Fatalf("expect error to contain %v, got %v", e, a)
+		}
+		return
+	} else if e := testData.ExpectGetError; len(e) != 0 {
+		t.Fatalf("expect error when getting object: %v, got none", e)
+	}
+
+	got, err := io.ReadAll(out.Body)
+	if err != nil {
+		if len(testData.ExpectReadError) == 0 {
+			t.Fatalf("expect no error when reading responses, got %v", err)
+		}
+		if e, a := testData.ExpectReadError, err.Error(); !strings.Contains(a, e) {
+			t.Fatalf("expect error to contain %v, got %v", e, a)
+		}
+		return
+	} else if e := testData.ExpectReadError; len(e) != 0 {
+		t.Fatalf("expect error when reading responses: %v, got none", e)
+	}
+
+	if e, a := testData.ExpectBody, got; !bytes.Equal(e, a) {
+		t.Errorf("expect streamed object to equal uploaded object: uploaded %d bytes, got %d bytes", len(e), len(a))
 	}
 }
 


### PR DESCRIPTION
Fixes #3526 for sequential GetObject. Basically part GET now is separated from range GET(range GET is unaffected). In new `partRead`, the reader still receives concurrent out chunks from s3, but only reads consecutive parts to destination slice  in every `Read`, the buffer is also expanded more conservative - only when all current received chunks are fully consumed and the threshold memory is not drained.

The concurrency of change was tested under some deadlock test in case some later non-consecutive huge parts occupied buffer and blocked all earlier small parts 