### PR TITLE
chore: update stale snapshots after credential source middleware removal

### DIFF
--- a/service/connect/snapshot/api_op_GetCrossRegionRouting.go.snap
+++ b/service/connect/snapshot/api_op_GetCrossRegionRouting.go.snap
@@ -7,7 +7,6 @@ GetCrossRegionRouting
 		OperationSerializer
 	Build stack step
 		ClientRequestID
-		SetCredentialSourceMiddleware
 		UserAgent
 		RecursionDetection
 	Finalize stack step

--- a/service/connect/snapshot/api_op_UpdateCrossRegionRouting.go.snap
+++ b/service/connect/snapshot/api_op_UpdateCrossRegionRouting.go.snap
@@ -7,7 +7,6 @@ UpdateCrossRegionRouting
 		OperationSerializer
 	Build stack step
 		ClientRequestID
-		SetCredentialSourceMiddleware
 		UserAgent
 		RecursionDetection
 	Finalize stack step

--- a/service/customerprofiles/snapshot/api_op_AssociateStreamForSegments.go.snap
+++ b/service/customerprofiles/snapshot/api_op_AssociateStreamForSegments.go.snap
@@ -7,7 +7,6 @@ AssociateStreamForSegments
 		OperationSerializer
 	Build stack step
 		ClientRequestID
-		SetCredentialSourceMiddleware
 		UserAgent
 		RecursionDetection
 	Finalize stack step

--- a/service/customerprofiles/snapshot/api_op_DeleteSegmentSubscription.go.snap
+++ b/service/customerprofiles/snapshot/api_op_DeleteSegmentSubscription.go.snap
@@ -7,7 +7,6 @@ DeleteSegmentSubscription
 		OperationSerializer
 	Build stack step
 		ClientRequestID
-		SetCredentialSourceMiddleware
 		UserAgent
 		RecursionDetection
 	Finalize stack step

--- a/service/customerprofiles/snapshot/api_op_DisassociateStreamForSegments.go.snap
+++ b/service/customerprofiles/snapshot/api_op_DisassociateStreamForSegments.go.snap
@@ -7,7 +7,6 @@ DisassociateStreamForSegments
 		OperationSerializer
 	Build stack step
 		ClientRequestID
-		SetCredentialSourceMiddleware
 		UserAgent
 		RecursionDetection
 	Finalize stack step

--- a/service/customerprofiles/snapshot/api_op_GetSegmentSubscription.go.snap
+++ b/service/customerprofiles/snapshot/api_op_GetSegmentSubscription.go.snap
@@ -7,7 +7,6 @@ GetSegmentSubscription
 		OperationSerializer
 	Build stack step
 		ClientRequestID
-		SetCredentialSourceMiddleware
 		UserAgent
 		RecursionDetection
 	Finalize stack step

--- a/service/customerprofiles/snapshot/api_op_GetStreamForSegments.go.snap
+++ b/service/customerprofiles/snapshot/api_op_GetStreamForSegments.go.snap
@@ -7,7 +7,6 @@ GetStreamForSegments
 		OperationSerializer
 	Build stack step
 		ClientRequestID
-		SetCredentialSourceMiddleware
 		UserAgent
 		RecursionDetection
 	Finalize stack step

--- a/service/customerprofiles/snapshot/api_op_ListSegmentSubscriptionEvents.go.snap
+++ b/service/customerprofiles/snapshot/api_op_ListSegmentSubscriptionEvents.go.snap
@@ -7,7 +7,6 @@ ListSegmentSubscriptionEvents
 		OperationSerializer
 	Build stack step
 		ClientRequestID
-		SetCredentialSourceMiddleware
 		UserAgent
 		RecursionDetection
 	Finalize stack step

--- a/service/customerprofiles/snapshot/api_op_PutSegmentSubscription.go.snap
+++ b/service/customerprofiles/snapshot/api_op_PutSegmentSubscription.go.snap
@@ -7,7 +7,6 @@ PutSegmentSubscription
 		OperationSerializer
 	Build stack step
 		ClientRequestID
-		SetCredentialSourceMiddleware
 		UserAgent
 		RecursionDetection
 	Finalize stack step

--- a/service/kafkaconnect/snapshot/api_op_RestartConnector.go.snap
+++ b/service/kafkaconnect/snapshot/api_op_RestartConnector.go.snap
@@ -7,7 +7,6 @@ RestartConnector
 		OperationSerializer
 	Build stack step
 		ClientRequestID
-		SetCredentialSourceMiddleware
 		UserAgent
 		RecursionDetection
 	Finalize stack step

--- a/service/kinesis/snapshot/api_op_CreateChannel.go.snap
+++ b/service/kinesis/snapshot/api_op_CreateChannel.go.snap
@@ -7,7 +7,6 @@ CreateChannel
 		OperationSerializer
 	Build stack step
 		ClientRequestID
-		SetCredentialSourceMiddleware
 		UserAgent
 		RecursionDetection
 	Finalize stack step

--- a/service/kinesis/snapshot/api_op_DeleteChannel.go.snap
+++ b/service/kinesis/snapshot/api_op_DeleteChannel.go.snap
@@ -7,7 +7,6 @@ DeleteChannel
 		OperationSerializer
 	Build stack step
 		ClientRequestID
-		SetCredentialSourceMiddleware
 		UserAgent
 		RecursionDetection
 	Finalize stack step

--- a/service/kinesis/snapshot/api_op_DescribeChannel.go.snap
+++ b/service/kinesis/snapshot/api_op_DescribeChannel.go.snap
@@ -7,7 +7,6 @@ DescribeChannel
 		OperationSerializer
 	Build stack step
 		ClientRequestID
-		SetCredentialSourceMiddleware
 		UserAgent
 		RecursionDetection
 	Finalize stack step

--- a/service/kinesis/snapshot/api_op_ListChannels.go.snap
+++ b/service/kinesis/snapshot/api_op_ListChannels.go.snap
@@ -7,7 +7,6 @@ ListChannels
 		OperationSerializer
 	Build stack step
 		ClientRequestID
-		SetCredentialSourceMiddleware
 		UserAgent
 		RecursionDetection
 	Finalize stack step

--- a/service/kinesis/snapshot/api_op_UpdateChannel.go.snap
+++ b/service/kinesis/snapshot/api_op_UpdateChannel.go.snap
@@ -7,7 +7,6 @@ UpdateChannel
 		OperationSerializer
 	Build stack step
 		ClientRequestID
-		SetCredentialSourceMiddleware
 		UserAgent
 		RecursionDetection
 	Finalize stack step

--- a/service/quicksight/snapshot/api_op_DeleteApp.go.snap
+++ b/service/quicksight/snapshot/api_op_DeleteApp.go.snap
@@ -7,7 +7,6 @@ DeleteApp
 		OperationSerializer
 	Build stack step
 		ClientRequestID
-		SetCredentialSourceMiddleware
 		UserAgent
 		RecursionDetection
 	Finalize stack step

--- a/service/quicksight/snapshot/api_op_DescribeApp.go.snap
+++ b/service/quicksight/snapshot/api_op_DescribeApp.go.snap
@@ -7,7 +7,6 @@ DescribeApp
 		OperationSerializer
 	Build stack step
 		ClientRequestID
-		SetCredentialSourceMiddleware
 		UserAgent
 		RecursionDetection
 	Finalize stack step

--- a/service/quicksight/snapshot/api_op_DescribeAppPermissions.go.snap
+++ b/service/quicksight/snapshot/api_op_DescribeAppPermissions.go.snap
@@ -7,7 +7,6 @@ DescribeAppPermissions
 		OperationSerializer
 	Build stack step
 		ClientRequestID
-		SetCredentialSourceMiddleware
 		UserAgent
 		RecursionDetection
 	Finalize stack step

--- a/service/quicksight/snapshot/api_op_ListApps.go.snap
+++ b/service/quicksight/snapshot/api_op_ListApps.go.snap
@@ -7,7 +7,6 @@ ListApps
 		OperationSerializer
 	Build stack step
 		ClientRequestID
-		SetCredentialSourceMiddleware
 		UserAgent
 		RecursionDetection
 	Finalize stack step

--- a/service/quicksight/snapshot/api_op_SearchApps.go.snap
+++ b/service/quicksight/snapshot/api_op_SearchApps.go.snap
@@ -7,7 +7,6 @@ SearchApps
 		OperationSerializer
 	Build stack step
 		ClientRequestID
-		SetCredentialSourceMiddleware
 		UserAgent
 		RecursionDetection
 	Finalize stack step

--- a/service/quicksight/snapshot/api_op_UpdateAppPermissions.go.snap
+++ b/service/quicksight/snapshot/api_op_UpdateAppPermissions.go.snap
@@ -7,7 +7,6 @@ UpdateAppPermissions
 		OperationSerializer
 	Build stack step
 		ClientRequestID
-		SetCredentialSourceMiddleware
 		UserAgent
 		RecursionDetection
 	Finalize stack step

--- a/service/support/snapshot/api_op_CompleteAttachmentUpload.go.snap
+++ b/service/support/snapshot/api_op_CompleteAttachmentUpload.go.snap
@@ -7,7 +7,6 @@ CompleteAttachmentUpload
 		OperationSerializer
 	Build stack step
 		ClientRequestID
-		SetCredentialSourceMiddleware
 		UserAgent
 		RecursionDetection
 	Finalize stack step

--- a/service/support/snapshot/api_op_DescribeAttachmentUploadStatus.go.snap
+++ b/service/support/snapshot/api_op_DescribeAttachmentUploadStatus.go.snap
@@ -7,7 +7,6 @@ DescribeAttachmentUploadStatus
 		OperationSerializer
 	Build stack step
 		ClientRequestID
-		SetCredentialSourceMiddleware
 		UserAgent
 		RecursionDetection
 	Finalize stack step

--- a/service/support/snapshot/api_op_GetAttachmentDownloadLink.go.snap
+++ b/service/support/snapshot/api_op_GetAttachmentDownloadLink.go.snap
@@ -7,7 +7,6 @@ GetAttachmentDownloadLink
 		OperationSerializer
 	Build stack step
 		ClientRequestID
-		SetCredentialSourceMiddleware
 		UserAgent
 		RecursionDetection
 	Finalize stack step

--- a/service/support/snapshot/api_op_GetAttachmentUploadLinks.go.snap
+++ b/service/support/snapshot/api_op_GetAttachmentUploadLinks.go.snap
@@ -7,7 +7,6 @@ GetAttachmentUploadLinks
 		OperationSerializer
 	Build stack step
 		ClientRequestID
-		SetCredentialSourceMiddleware
 		UserAgent
 		RecursionDetection
 	Finalize stack step


### PR DESCRIPTION
# Description                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                          
Fixes the `test-ci-check-snapshot-service` failure on `main`.                                                                                                                                                                                           
                                                                                                                                                                                                                                                          
#3539 stopped generating `SetCredentialSourceMiddleware`. Concurrently, added 25 new operations whose snapshots were generated with the previous codegen and still list it. The commits touched disjoint files, so the merge was clean but left the snapshots inconsistent.                                                                                                                                                                                                    

Affected: `connect` (2), `customerprofiles` (7), `kinesis` (5), `quicksight` (6), `support` (4), `kafkaconnect` (1).                                                                                                                                                                                                                      

# Testing
Regenerated with `make test-update-snapshot-service`. `TestCheckSnapshot` passes for all six services.
