### PR TITLE
fix(appstream): handle null map values in deserializeMetadata

### DIFF
--- a/service/appstream/types/common_serde.go
+++ b/service/appstream/types/common_serde.go
@@ -1428,6 +1428,12 @@ func deserializeMetadata(d smithy.ShapeDeserializer, s *smithy.Schema, v *map[st
 	var vv string
 	return smithy.ReadMap(d, s, func(k string) error {
 
+		if isNil, err := d.ReadNil(s.MapValue()); err != nil {
+			return err
+		} else if isNil {
+			return nil
+		}
+
 		if err := d.ReadString(s.MapValue(), &vv); err != nil {
 			return err
 		}


### PR DESCRIPTION
Fixes `unexpected value type *cbor.Nil` when calling `DescribeImages` if any `Application.Metadata` map value is explicitly null (e.g. `WORKING_DIRECTORY: null`).

The AppStream service returns explicit CBOR null values for optional metadata fields. The `deserializeMetadata` function called `ReadString` directly without first checking for null, causing the CBOR deserializer to crash.

Added a `ReadNil` check before `ReadString` to consume and skip null values gracefully.

Fixes #3501
